### PR TITLE
Fixed an issue where object pointers in a soft key mask were invisible

### DIFF
--- a/src/SoftKeyMaskComponent.cpp
+++ b/src/SoftKeyMaskComponent.cpp
@@ -9,8 +9,8 @@
 SoftKeyMaskComponent::SoftKeyMaskComponent(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, isobus::SoftKeyMask sourceObject, int dataAndAlarmMaskSize, int keyHeight, int keyWidth) :
   isobus::SoftKeyMask(sourceObject),
   parentWorkingSet(workingSet),
-	softKeyHeight(keyHeight),
-	softKeyWidth(keyWidth)
+  softKeyHeight(keyHeight),
+  softKeyWidth(keyWidth)
 {
 	setOpaque(true);
 	setBounds(0, 0, softKeyWidth > 80 ? softKeyWidth + 20 : 100, dataAndAlarmMaskSize);
@@ -26,6 +26,11 @@ void SoftKeyMaskComponent::on_content_changed(bool initial)
 		if (nullptr != child)
 		{
 			childComponents.push_back(JuceManagedWorkingSetCache::create_component(parentWorkingSet, child));
+
+			if (isobus::VirtualTerminalObjectType::ObjectPointer == child->get_object_type())
+			{
+				childComponents.back()->setSize(softKeyWidth, softKeyHeight);
+			}
 
 			if (nullptr != childComponents.back())
 			{


### PR DESCRIPTION
- Fixed not setting the size of an object pointer's render area in a soft key mask to be the key size, which was causing the size to be zero, which caused it to be not visible.