### PR TITLE
Update CMake reference to CAN Stack

### DIFF
--- a/cmake/FindCAN_Stack.cmake
+++ b/cmake/FindCAN_Stack.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   CAN_Stack
   GIT_REPOSITORY https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git
-  GIT_TAG vt-server-managed-working-set
+  GIT_TAG 29dab887a48bb204aae983b06052d52b0f2314d5
 )
 FetchContent_MakeAvailable(CAN_Stack)
 endif()


### PR DESCRIPTION
Now that the VT server PR is merged on the main stack, this change starts explicitly setting the commit of the stack to use when building the VT.

This will:

- Reduce the number of times fetch content has to check the upstream repo
- Prevent rebase issues that can happen when tracking a branch, reducing the need to clean and rebuild the CMake cache
- Provide tighter control over our largest dependency (the stack)