### PR TITLE
Implemented "Still Held" key activation messages

### DIFF
--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -99,6 +99,9 @@ public:
 
 	void change_selected_working_set(std::uint8_t index);
 
+	void set_button_held(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, std::uint16_t objectID, std::uint16_t maskObjectID, std::uint8_t keyCode, bool isSoftKey);
+	void set_button_released(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, std::uint16_t objectID, std::uint16_t maskObjectID, std::uint8_t keyCode, bool isSoftKey);
+
 	void repaint_on_next_update();
 
 	void save_settings();
@@ -129,6 +132,18 @@ private:
 	};
 	friend class LanguageCommandConfigClosed;
 
+	struct HeldButtonData
+	{
+		HeldButtonData(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, std::uint16_t objectID, std::uint16_t maskObjectID, std::uint8_t keyCode, bool isSoftKey);
+		bool operator==(const HeldButtonData &other);
+		std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> associatedWorkingSet;
+		std::uint32_t timestamp_ms;
+		std::uint16_t buttonObjectID;
+		std::uint16_t activeMaskObjectID;
+		std::uint8_t buttonKeyCode;
+		bool isSoftKey;
+	};
+
 	static VTVersion get_version_from_setting(std::uint8_t aVersion);
 
 	std::size_t number_of_iop_files_in_directory(std::filesystem::path path);
@@ -153,6 +168,7 @@ private:
 	std::unique_ptr<AlertWindow> popupMenu;
 	std::unique_ptr<ConfigureHardwareWindow> configureHardwareWindow;
 	std::vector<std::shared_ptr<isobus::CANHardwarePlugin>> &parentCANDrivers;
+	std::vector<HeldButtonData> heldButtons;
 	std::uint8_t numberOfPoolsToRender = 0;
 	std::uint8_t numberPhysicalSoftKeys = 6;
 	std::uint8_t numberVirtualSoftKeys = 64;

--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -96,6 +96,11 @@ void DataMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 				                                           activeMask->get_id(),
 				                                           keyCode,
 				                                           ownerServer.get_active_working_set()->get_control_function());
+				ownerServer.set_button_held(ownerServer.get_active_working_set(),
+				                            clickedObject->get_id(),
+				                            activeMask->get_id(),
+				                            keyCode,
+				                            (isobus::VirtualTerminalObjectType::Key == clickedObject->get_object_type()));
 			}
 		}
 	}
@@ -133,6 +138,11 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 							                                           keyCode,
 							                                           ownerServer.get_active_working_set()->get_control_function());
 							ownerServer.process_macro(clickedObject, isobus::EventID::OnKeyRelease, isobus::VirtualTerminalObjectType::Button, parentWorkingSet);
+							ownerServer.set_button_released(ownerServer.get_active_working_set(),
+							                                clickedObject->get_id(),
+							                                activeMask->get_id(),
+							                                keyCode,
+							                                true);
 						}
 					}
 					break;
@@ -146,6 +156,11 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 						                                           keyCode,
 						                                           ownerServer.get_active_working_set()->get_control_function());
 						ownerServer.process_macro(clickedObject, isobus::EventID::OnKeyRelease, isobus::VirtualTerminalObjectType::Key, parentWorkingSet);
+						ownerServer.set_button_released(ownerServer.get_active_working_set(),
+						                                clickedObject->get_id(),
+						                                activeMask->get_id(),
+						                                keyCode,
+						                                true);
 					}
 					break;
 

--- a/src/SoftkeyMaskRenderArea.cpp
+++ b/src/SoftkeyMaskRenderArea.cpp
@@ -120,6 +120,11 @@ void SoftKeyMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 				                                             activeMask->get_id(),
 				                                             keyCode,
 				                                             ownerServer.get_active_working_set()->get_control_function());
+				ownerServer.set_button_held(ownerServer.get_active_working_set(),
+				                            clickedObject->get_id(),
+				                            activeMask->get_id(),
+				                            keyCode,
+				                            true);
 			}
 		}
 	}
@@ -174,6 +179,11 @@ void SoftKeyMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 				                                             activeMask->get_id(),
 				                                             keyCode,
 				                                             ownerServer.get_active_working_set()->get_control_function());
+				ownerServer.set_button_released(ownerServer.get_active_working_set(),
+				                                clickedObject->get_id(),
+				                                activeMask->get_id(),
+				                                keyCode,
+				                                true);
 			}
 		}
 	}


### PR DESCRIPTION
## What's New

This change should allow the VT to properly handle when buttons and soft keys are held. Previously, only press and release were implemented.

- Add key/button activation messages for "Still held", sent every 200ms the mouse remains down over a component of key or button type.
- Clarified in-app language about license to match the rest of the repo.

Closes #19 