### PR TITLE
Output Bar Graph and Output Rectangle fixes

### DIFF
--- a/src/OutputLinearBarGraphComponent.cpp
+++ b/src/OutputLinearBarGraphComponent.cpp
@@ -17,9 +17,15 @@ OutputLinearBarGraphComponent::OutputLinearBarGraphComponent(std::shared_ptr<iso
 void OutputLinearBarGraphComponent::paint(Graphics &g)
 {
 	float valueRatioToMax = static_cast<float>(get_value()) / static_cast<float>(get_max_value());
+	float targetRatioToMax = static_cast<float>(get_target_value()) / static_cast<float>(get_max_value());
 	auto vtBackgroundColour = parentWorkingSet->get_colour(get_colour());
 	auto vtTargetLineColour = parentWorkingSet->get_colour(get_target_line_colour());
 	g.setColour(Colour::fromFloatRGBA(vtBackgroundColour.r, vtBackgroundColour.g, vtBackgroundColour.b, 1.0));
+
+	if (get_option(Options::DrawBorder))
+	{
+		g.drawRect(0, 0, getWidth(), getHeight(), 3);
+	}
 
 	if (isobus::NULL_OBJECT_ID != get_variable_reference())
 	{
@@ -42,10 +48,24 @@ void OutputLinearBarGraphComponent::paint(Graphics &g)
 			if (get_option(Options::Direction))
 			{
 				// From left
+				g.drawLine(static_cast<float>(get_width()) * valueRatioToMax, 0.0f, static_cast<float>(get_width()) * valueRatioToMax, static_cast<float>(get_height()), 3);
+
+				if (get_option(Options::DrawTargetLine))
+				{
+					g.setColour(Colour::fromFloatRGBA(vtTargetLineColour.r, vtTargetLineColour.g, vtTargetLineColour.b, 1.0));
+					g.drawVerticalLine(static_cast<float>(get_width()) * targetRatioToMax, 0.0f, static_cast<float>(get_height()));
+				}
 			}
 			else
 			{
 				// From right
+				g.drawLine(static_cast<float>(get_width()) * (1.0f - valueRatioToMax), 0.0f, static_cast<float>(get_width()) * (1.0f - valueRatioToMax), static_cast<float>(get_height()), 3);
+
+				if (get_option(Options::DrawTargetLine))
+				{
+					g.setColour(Colour::fromFloatRGBA(vtTargetLineColour.r, vtTargetLineColour.g, vtTargetLineColour.b, 1.0));
+					g.drawVerticalLine(static_cast<float>(get_width()) * (1.0f - targetRatioToMax), 0.0f, static_cast<float>(get_height()));
+				}
 			}
 		}
 		else
@@ -53,11 +73,25 @@ void OutputLinearBarGraphComponent::paint(Graphics &g)
 			// Y Axis
 			if (get_option(Options::Direction))
 			{
-				// From left
+				// From bottom
+				g.drawLine(0, (1.0f - valueRatioToMax) * getHeight(), getWidth(), (1.0f - valueRatioToMax) * getHeight(), 3);
+
+				if (get_option(Options::DrawTargetLine))
+				{
+					g.setColour(Colour::fromFloatRGBA(vtTargetLineColour.r, vtTargetLineColour.g, vtTargetLineColour.b, 1.0));
+					g.drawHorizontalLine(static_cast<float>(get_height() * (1.0f - targetRatioToMax)), 0.0f, static_cast<float>(get_width()));
+				}
 			}
 			else
 			{
-				// From right
+				// From top
+				g.drawLine(0, valueRatioToMax * getHeight(), getWidth(), valueRatioToMax * getHeight(), 3);
+
+				if (get_option(Options::DrawTargetLine))
+				{
+					g.setColour(Colour::fromFloatRGBA(vtTargetLineColour.r, vtTargetLineColour.g, vtTargetLineColour.b, 1.0));
+					g.drawHorizontalLine(static_cast<float>(get_height() * targetRatioToMax), 0.0f, static_cast<float>(get_width()));
+				}
 			}
 		}
 	}
@@ -72,11 +106,23 @@ void OutputLinearBarGraphComponent::paint(Graphics &g)
 			{
 				// From left
 				g.fillRect(0.0f, 0.0f, static_cast<float>(get_width()) * valueRatioToMax, static_cast<float>(get_height()));
+
+				if (get_option(Options::DrawTargetLine))
+				{
+					g.setColour(Colour::fromFloatRGBA(vtTargetLineColour.r, vtTargetLineColour.g, vtTargetLineColour.b, 1.0));
+					g.drawVerticalLine(static_cast<float>(get_width()) * targetRatioToMax, 0.0f, static_cast<float>(get_height()));
+				}
 			}
 			else
 			{
 				// From right
 				g.fillRect(static_cast<float>(get_width()) * (1 - valueRatioToMax), 0.0f, static_cast<float>(get_width()) * valueRatioToMax, static_cast<float>(get_height()));
+
+				if (get_option(Options::DrawTargetLine))
+				{
+					g.setColour(Colour::fromFloatRGBA(vtTargetLineColour.r, vtTargetLineColour.g, vtTargetLineColour.b, 1.0));
+					g.drawVerticalLine(static_cast<float>(get_width()) * (1 - targetRatioToMax), 0.0f, static_cast<float>(get_height()));
+				}
 			}
 		}
 		else
@@ -86,11 +132,23 @@ void OutputLinearBarGraphComponent::paint(Graphics &g)
 			{
 				// From bottom
 				g.fillRect(0.0f, static_cast<float>(get_height() * (1 - valueRatioToMax)), static_cast<float>(get_width()), static_cast<float>(get_height()) * valueRatioToMax);
+
+				if (get_option(Options::DrawTargetLine))
+				{
+					g.setColour(Colour::fromFloatRGBA(vtTargetLineColour.r, vtTargetLineColour.g, vtTargetLineColour.b, 1.0));
+					g.drawHorizontalLine(static_cast<float>(get_height() * (1 - targetRatioToMax)), 0.0f, static_cast<float>(get_width()));
+				}
 			}
 			else
 			{
 				// From top
 				g.fillRect(0.0f, 0.0f, static_cast<float>(get_width()), static_cast<float>(get_height()) * valueRatioToMax);
+
+				if (get_option(Options::DrawTargetLine))
+				{
+					g.setColour(Colour::fromFloatRGBA(vtTargetLineColour.r, vtTargetLineColour.g, vtTargetLineColour.b, 1.0));
+					g.drawHorizontalLine(static_cast<float>(get_height() * targetRatioToMax), 0.0f, static_cast<float>(get_width()));
+				}
 			}
 		}
 	}

--- a/src/OutputRectangleComponent.cpp
+++ b/src/OutputRectangleComponent.cpp
@@ -37,18 +37,15 @@ void OutputRectangleComponent::paint(Graphics &g)
 
 				case isobus::FillAttributes::FillType::FillWithLineColor:
 				{
-					for (std::uint16_t j = 0; j < get_number_children(); j++)
-					{
-						auto childLineAttributes = get_object_by_id(get_child_id(j), parentWorkingSet->get_object_tree());
+					auto childLineAttributes = get_object_by_id(get_line_attributes(), parentWorkingSet->get_object_tree());
 
-						if ((nullptr != childLineAttributes) && (isobus::VirtualTerminalObjectType::LineAttributes == childLineAttributes->get_object_type()))
-						{
-							auto line = std::static_pointer_cast<isobus::LineAttributes>(childLineAttributes);
-							vtColour = parentWorkingSet->get_colour(line->get_background_color());
-							g.setColour(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0));
-							g.fillAll(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0f));
-							break;
-						}
+					if ((nullptr != childLineAttributes) && (isobus::VirtualTerminalObjectType::LineAttributes == childLineAttributes->get_object_type()))
+					{
+						auto line = std::static_pointer_cast<isobus::LineAttributes>(childLineAttributes);
+						vtColour = parentWorkingSet->get_colour(line->get_background_color());
+						g.setColour(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0));
+						g.fillAll(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0f));
+						break;
 					}
 					isOpaque = true;
 				}


### PR DESCRIPTION
- Fixed various drawing issues with output linear bar graph objects
    - Added rendering of target line
    - Fixed un-filled bar graphs being completely broken
    - Fixed drawing borders of bar graphs not working at all
- Fixed output rectangle would not be filled correctly if the fill attribute indicated that the line attribute associated to the rectangle was to be used for the fill