### PR TITLE
Add rendering of UTF-16 Strings

### DIFF
--- a/cmake/FindCAN_Stack.cmake
+++ b/cmake/FindCAN_Stack.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   CAN_Stack
   GIT_REPOSITORY https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git
-  GIT_TAG 29dab887a48bb204aae983b06052d52b0f2314d5
+  GIT_TAG 80a1823e62ab65eb660cf1c1f9231d5fd9c7fc7f
 )
 FetchContent_MakeAvailable(CAN_Stack)
 endif()

--- a/src/InputStringComponent.cpp
+++ b/src/InputStringComponent.cpp
@@ -82,13 +82,28 @@ void InputStringComponent::paint(Graphics &g)
 		fontHeight = 8;
 	}
 
+	String decodedValue(value);
+
+	if ((value.length() >= 2) &&
+	    (0xFF == static_cast<std::uint8_t>(value.at(0))) &&
+	    (0xFE == static_cast<std::uint8_t>(value.at(1))))
+	{
+		// String is UTF-16 encoded.
+		if (0 != (value.length() % 2))
+		{
+			// If the length attribute does not indicate an even number of bytes the last byte is ignored
+			value.pop_back();
+		}
+		decodedValue = String::createStringFromData(value.c_str(), value.size());
+	}
+
 	if (get_option(Options::AutoWrap)) // TODO need to figure out proper font clipping
 	{
-		g.drawFittedText(value, 0, 0, get_width(), get_height(), convert_justification(get_horizontal_justification(), get_vertical_justification()), static_cast<int>(std::floor((static_cast<float>(get_height()) + 0.1f) / fontHeight)), 0.8f);
+		g.drawFittedText(decodedValue, 0, 0, get_width(), get_height(), convert_justification(get_horizontal_justification(), get_vertical_justification()), static_cast<int>(std::floor((static_cast<float>(get_height()) + 0.1f) / fontHeight)), 0.8f);
 	}
 	else
 	{
-		g.drawFittedText(value, 0, 0, get_width(), get_height(), convert_justification(get_horizontal_justification(), get_vertical_justification()), static_cast<int>(std::floor((static_cast<float>(get_height()) + 0.1f) / fontHeight)), 0.8f);
+		g.drawFittedText(decodedValue, 0, 0, get_width(), get_height(), convert_justification(get_horizontal_justification(), get_vertical_justification()), static_cast<int>(std::floor((static_cast<float>(get_height()) + 0.1f) / fontHeight)), 0.8f);
 	}
 
 	// If disabled, try and show that by drawing some semi-transparent grey

--- a/src/OutputStringComponent.cpp
+++ b/src/OutputStringComponent.cpp
@@ -81,13 +81,28 @@ void OutputStringComponent::paint(Graphics &g)
 		fontHeight = 8;
 	}
 
+	String decodedValue(value);
+
+	if ((value.length() >= 2) &&
+	    (0xFF == static_cast<std::uint8_t>(value.at(0))) &&
+	    (0xFE == static_cast<std::uint8_t>(value.at(1))))
+	{
+		// String is UTF-16 encoded, font type is ignored.
+		if (0 != (value.length() % 2))
+		{
+			// If the length attribute does not indicate an even number of bytes the last byte is ignored
+			value.pop_back();
+		}
+		decodedValue = String::createStringFromData(value.c_str(), value.size());
+	}
+
 	if (get_option(Options::AutoWrap)) // TODO need to figure out proper font clipping
 	{
-		g.drawFittedText(value, 0, 0, get_width(), get_height(), convert_justification(get_horizontal_justification(), get_vertical_justification()), static_cast<int>(std::floor((static_cast<float>(get_height()) + 0.1f) / fontHeight)), 0.8f);
+		g.drawFittedText(decodedValue, 0, 0, get_width(), get_height(), convert_justification(get_horizontal_justification(), get_vertical_justification()), static_cast<int>(std::floor((static_cast<float>(get_height()) + 0.1f) / fontHeight)), 0.8f);
 	}
 	else
 	{
-		g.drawFittedText(value, 0, 0, get_width(), get_height(), convert_justification(get_horizontal_justification(), get_vertical_justification()), static_cast<int>(std::floor((static_cast<float>(get_height()) + 0.1f) / fontHeight)), 0.8f);
+		g.drawFittedText(decodedValue, 0, 0, get_width(), get_height(), convert_justification(get_horizontal_justification(), get_vertical_justification()), static_cast<int>(std::floor((static_cast<float>(get_height()) + 0.1f) / fontHeight)), 0.8f);
 	}
 }
 


### PR DESCRIPTION
Previously, UTF-16 strings were not tolerated in the object pool. Now they will properly get rendered (in theory).

![image](https://github.com/user-attachments/assets/4830b65c-57b1-4be0-8ae2-88e27e14c5d3)

Closes #27 

I will address issues with the ISO 8859 encodings in a separate ticket as they are going to be more involved.