### PR TITLE
Fix parent object ID in the key events

### DIFF
--- a/src/SoftkeyMaskRenderArea.cpp
+++ b/src/SoftkeyMaskRenderArea.cpp
@@ -81,6 +81,7 @@ void SoftKeyMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 		if (nullptr != workingSetObject)
 		{
 			auto activeMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
+			auto parentMask = activeMask;
 
 			if (isobus::VirtualTerminalObjectType::AlarmMask == activeMask->get_object_type())
 			{
@@ -117,7 +118,7 @@ void SoftKeyMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 
 				ownerServer.send_soft_key_activation_message(isobus::VirtualTerminalBase::KeyActivationCode::ButtonPressedOrLatched,
 				                                             clickedObject->get_id(),
-				                                             activeMask->get_id(),
+				                                             parentMask->get_id(),
 				                                             keyCode,
 				                                             ownerServer.get_active_working_set()->get_control_function());
 				ownerServer.set_button_held(ownerServer.get_active_working_set(),
@@ -140,6 +141,7 @@ void SoftKeyMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 		if (nullptr != workingSetObject)
 		{
 			auto activeMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
+			auto parentMask = activeMask;
 
 			if (isobus::VirtualTerminalObjectType::AlarmMask == activeMask->get_object_type())
 			{
@@ -176,7 +178,7 @@ void SoftKeyMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 
 				ownerServer.send_soft_key_activation_message(isobus::VirtualTerminalBase::KeyActivationCode::ButtonUnlatchedOrReleased,
 				                                             clickedObject->get_id(),
-				                                             activeMask->get_id(),
+				                                             parentMask->get_id(),
 				                                             keyCode,
 				                                             ownerServer.get_active_working_set()->get_control_function());
 				ownerServer.set_button_released(ownerServer.get_active_working_set(),


### PR DESCRIPTION
First of all many thanks for creating for this wonderful software!
I am waiting this to be happen (open source VT implementation) since I started to work in the agricultural industry. 

I came across a VT client where the softkeys did not worked. 
With some debugging it turned out that the parent ID was checked in the key events and it was expected to be one of the data mask's IDs.

The standard says:
H.2 Soft Key Activation message
Bytes 5, 6 -  Parent Object ID:
Object ID of visible Data Mask, Alarm Mask, or in the case where the Soft Key is in a visible Key Group, the Object ID of the Key Group Object
