### PR TITLE
Do not send button held messages for non button/key objects

### DIFF
--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -96,11 +96,15 @@ void DataMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 				                                           activeMask->get_id(),
 				                                           keyCode,
 				                                           ownerServer.get_active_working_set()->get_control_function());
-				ownerServer.set_button_held(ownerServer.get_active_working_set(),
-				                            clickedObject->get_id(),
-				                            activeMask->get_id(),
-				                            keyCode,
-				                            (isobus::VirtualTerminalObjectType::Key == clickedObject->get_object_type()));
+				if (isobus::VirtualTerminalObjectType::Key == clickedObject->get_object_type() ||
+					isobus::VirtualTerminalObjectType::Button == clickedObject->get_object_type())
+				{
+					ownerServer.set_button_held(ownerServer.get_active_working_set(),
+												clickedObject->get_id(),
+												activeMask->get_id(),
+												keyCode,
+												(isobus::VirtualTerminalObjectType::Key == clickedObject->get_object_type()));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When non button/key objects clicked on the datamask the key hold event kept sent continuously for non key/button objects.
This PR will prevent the sending held events for non key/button objects.

Fixed #37