### PR TITLE
Updated CMake and Hardware selector to allow building with MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,12 @@ set(BUILD_TESTING OFF)
 if(WIN32)
     set(CAN_DRIVER "WindowsPCANBasic")
     list(APPEND CAN_DRIVER "TouCAN")
-    list(APPEND CAN_DRIVER "WindowsInnoMakerUSB2CAN")
+
+    if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND MINGW))
+      list(APPEND CAN_DRIVER "WindowsInnoMakerUSB2CAN")
+    else()
+      message(STATUS "InnoMaker hardware will not be supported in this build because you are using mingw")
+    endif()
     list(APPEND CAN_DRIVER "SYS_TEC")
 elseif(APPLE)
     set(CAN_DRIVER "MacCANPCAN")
@@ -91,7 +96,7 @@ target_link_libraries(
           isobus::Utility
   PUBLIC juce::juce_recommended_config_flags juce::juce_recommended_lto_flags)
 
-if(MSVC)
+if(WIN32)
     add_custom_command(
             TARGET AgISOVirtualTerminal POST_BUILD
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${CMAKE_CURRENT_LIST_DIR}/lib/PCANBasic.dll "$<TARGET_FILE_DIR:AgISOVirtualTerminal>"

--- a/src/ConfigureHardwareComponent.cpp
+++ b/src/ConfigureHardwareComponent.cpp
@@ -28,13 +28,18 @@ ConfigureHardwareComponent::ConfigureHardwareComponent(ConfigureHardwareWindow &
 #ifdef JUCE_WINDOWS
 	hardwareInterfaceSelector.setName("Hardware Interface");
 	hardwareInterfaceSelector.setTextWhenNothingSelected("Select Hardware Interface");
-	hardwareInterfaceSelector.addItemList({ "PEAK PCAN USB", "Innomaker2CAN", "TouCAN", "SysTec" }, 1);
 
+#ifdef ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE
+	hardwareInterfaceSelector.addItemList({ "PEAK PCAN USB", "Innomaker2CAN", "TouCAN", "SysTec" }, 1);
+#else
+	hardwareInterfaceSelector.addItemList({ "PEAK PCAN USB", "Innomaker2CAN (not supported with mingw)", "TouCAN", "SysTec" }, 1);
+#endif
 	int selectedID = 1;
 
 	for (std::uint8_t i = 0; i < parentCANDrivers.size(); i++)
 	{
-		if (parentCANDrivers.at(i) == isobus::CANHardwareInterface::get_assigned_can_channel_frame_handler(0))
+		if ((nullptr != parentCANDrivers.at(i)) && 
+			(parentCANDrivers.at(i) == isobus::CANHardwareInterface::get_assigned_can_channel_frame_handler(0)))
 		{
 			selectedID = i + 1;
 			break;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -77,7 +77,11 @@ public:
 		{
 #ifdef JUCE_WINDOWS
 			canDrivers.push_back(std::make_shared<isobus::PCANBasicWindowsPlugin>(static_cast<WORD>(PCAN_USBBUS1)));
+#ifdef ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE
 			canDrivers.push_back(std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0));
+#else
+			canDrivers.push_back(nullptr);
+#endif
 			canDrivers.push_back(std::make_shared<isobus::TouCANPlugin>(static_cast<std::int16_t>(0), 0));
 			canDrivers.push_back(std::make_shared<isobus::SysTecWindowsPlugin>());
 #elif defined(JUCE_MAC)


### PR DESCRIPTION
- This change should allow all the CAN driver DLLs to get properly copied to the build directory when building with mingw
- Fixed linker issues with MinGW which were happening because the Innomaker driver is not compatible with MinGW (only MSVC)

Compiling with MinGW will exclude support for Innomaker.

Closes #34 