### PR TITLE
Display selected value in the InputList selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Supported features:
 - Output meter (except tick marks and target line)
 - Picture graphics (with and without run-length encoding)
 - Output Strings (partial - font clipping is not compliant)
-- Input lists (partial - drawing the selector needs work)
+- Input lists
 - Most relevant VT server CAN messages
 - Logging
 - Multiple simultaneous VT clients

--- a/cmake/FindCAN_Stack.cmake
+++ b/cmake/FindCAN_Stack.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   CAN_Stack
   GIT_REPOSITORY https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git
-  GIT_TAG 80a1823e62ab65eb660cf1c1f9231d5fd9c7fc7f
+  GIT_TAG 67e231298f2ca8367d437d903e396aa3bcefe080
 )
 FetchContent_MakeAvailable(CAN_Stack)
 endif()

--- a/src/OutputStringComponent.cpp
+++ b/src/OutputStringComponent.cpp
@@ -17,7 +17,7 @@ OutputStringComponent::OutputStringComponent(std::shared_ptr<isobus::VirtualTerm
 
 void OutputStringComponent::paint(Graphics &g)
 {
-	std::string value = get_value();
+	std::string value = displayed_value(parentWorkingSet);
 	std::uint8_t fontHeight = 0;
 	auto fontType = isobus::FontAttributes::FontType::ISO8859_1;
 
@@ -67,16 +67,6 @@ void OutputStringComponent::paint(Graphics &g)
 			juceFont.setHorizontalScale(static_cast<float>(font->get_font_width_pixels()) / fontWidth);
 			g.setColour(Colour::fromFloatRGBA(colour.r, colour.g, colour.b, 1.0f));
 			g.setFont(juceFont);
-		}
-	}
-
-	if (isobus::NULL_OBJECT_ID != get_variable_reference())
-	{
-		auto child = get_object_by_id(get_variable_reference(), parentWorkingSet->get_object_tree());
-
-		if ((nullptr != child) && (isobus::VirtualTerminalObjectType::StringVariable == child->get_object_type()))
-		{
-			value = std::static_pointer_cast<isobus::StringVariable>(child)->get_value();
 		}
 	}
 


### PR DESCRIPTION
The input list selector displayed Object <object id> after the selection, and did not displayed the currently displayed value (no value had been selected). 

This PR is dependent on the Open-Agriculture/AgIsoStack-plus-plus#506