### PR TITLE
Call macros on alarm or data mask change

### DIFF
--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -1308,11 +1308,16 @@ void ServerMainComponent::on_change_active_mask_callback(std::shared_ptr<isobus:
 					default:
 						break;
 				}
+				process_macro(activeMask, isobus::EventID::OnShow, isobus::VirtualTerminalObjectType::AlarmMask, activeWorkingSet);
+				process_macro(activeMask, isobus::EventID::OnChangeActiveMask, isobus::VirtualTerminalObjectType::AlarmMask, activeWorkingSet);
 			}
 			else if (isobus::VirtualTerminalObjectType::DataMask == activeMask->get_object_type())
 			{
 				auto dataMask = std::static_pointer_cast<isobus::DataMask>(activeMask);
 				activeWorkingSetSoftkeyMaskObjectID = dataMask->get_soft_key_mask();
+				// Also process macros for the actual datamask (container) show event
+				process_macro(activeMask, isobus::EventID::OnShow, isobus::VirtualTerminalObjectType::DataMask, activeWorkingSet);
+				process_macro(activeMask, isobus::EventID::OnChangeActiveMask, isobus::VirtualTerminalObjectType::DataMask, activeWorkingSet);
 			}
 		}
 	}


### PR DESCRIPTION
We have a feature for checking datamask changes by on triggering macros attached to the On Show events of a specific datamask. 

It had been working with wide range of terminals, however the AgIsoVT did not called these macros. 
I have added the calling of both On Show and On Active Mask change to the mask change event handling. 

I have not been able to find the specified sequence of the Show / Active Mask change events in the specs.
My internal intention says that first the mask needs to be shown and then should be considered active.