### PR TITLE
Cast min and max values as float in the InputNumber range calculation

### DIFF
--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -309,7 +309,8 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 							}
 
 							inputNumberSlider.reset(new Slider(Slider::SliderStyle::LinearHorizontal, Slider::TextBoxAbove));
-							inputNumberSlider->setRange((clickedNumber->get_minimum_value() + clickedNumber->get_offset()) * clickedNumber->get_scale(), (clickedNumber->get_maximum_value() + clickedNumber->get_offset()) * clickedNumber->get_scale());
+							inputNumberSlider->setRange((static_cast<float>(clickedNumber->get_minimum_value()) + clickedNumber->get_offset()) * clickedNumber->get_scale(),
+							                            (static_cast<float>(clickedNumber->get_maximum_value()) + clickedNumber->get_offset()) * clickedNumber->get_scale());
 							inputNumberSlider->setNumDecimalPlacesToDisplay(clickedNumber->get_number_of_decimals());
 							inputNumberSlider->setValue(scaledValue, NotificationType::dontSendNotification);
 							inputNumberSlider->setSize(400, 80);


### PR DESCRIPTION
I came across a segfault when tried to edit an InputNumber in a Kverneland implement.
The min was 0 max was 40 and the offset was -20. The type conversion resulted an unsinged result which lead to setting a very high minimum which triggered an assert in Juce.