### PR TITLE
Use proper color when painting InputNumber

### DIFF
--- a/src/InputNumberComponent.cpp
+++ b/src/InputNumberComponent.cpp
@@ -44,7 +44,7 @@ void InputNumberComponent::paint(Graphics &g)
 		    (isobus::VirtualTerminalObjectType::FontAttributes == child->get_object_type()))
 		{
 			auto font = std::static_pointer_cast<isobus::FontAttributes>(child);
-			auto colour = parentWorkingSet->get_colour(font->get_background_color());
+			auto colour = parentWorkingSet->get_colour(font->get_colour());
 			Font juceFont(Font::getDefaultMonospacedFontName(), font->get_font_height_pixels(), Font::FontStyleFlags::plain);
 			auto fontWidth = juceFont.getStringWidthFloat("1");
 			juceFont.setHorizontalScale(static_cast<float>(font->get_font_width_pixels()) / fontWidth);


### PR DESCRIPTION
I came across invisible input numbers here:

![kép](https://github.com/user-attachments/assets/db0d6e3a-b610-4fcb-9165-725b18ae6616)

AFter the change:
![kép](https://github.com/user-attachments/assets/179d7198-d2a6-4b1c-b46e-cb226f29a19a)
