### PR TITLE
Prevent segfault when inputlist variable reference is not set

### DIFF
--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -187,16 +187,20 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 							auto comboPopup = combo->getRootMenu();
 
 							auto selectedIndex = -1;
-							auto child = clickedList->get_object_by_id(clickedList->get_variable_reference(), parentWorkingSet->get_object_tree());
-							if (isobus::VirtualTerminalObjectType::NumberVariable == child->get_object_type())
+
+							if (clickedList->get_variable_reference() != isobus::NULL_OBJECT_ID)
 							{
 								auto child = clickedList->get_object_by_id(clickedList->get_variable_reference(), parentWorkingSet->get_object_tree());
-
-								if (nullptr != child)
+								if (isobus::VirtualTerminalObjectType::NumberVariable == child->get_object_type())
 								{
-									if (isobus::VirtualTerminalObjectType::NumberVariable == child->get_object_type())
+									auto child = clickedList->get_object_by_id(clickedList->get_variable_reference(), parentWorkingSet->get_object_tree());
+
+									if (nullptr != child)
 									{
-										selectedIndex = std::static_pointer_cast<isobus::NumberVariable>(child)->get_value();
+										if (isobus::VirtualTerminalObjectType::NumberVariable == child->get_object_type())
+										{
+											selectedIndex = std::static_pointer_cast<isobus::NumberVariable>(child)->get_value();
+										}
 									}
 								}
 							}

--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -190,17 +190,13 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 
 							if (clickedList->get_variable_reference() != isobus::NULL_OBJECT_ID)
 							{
-								auto child = clickedList->get_object_by_id(clickedList->get_variable_reference(), parentWorkingSet->get_object_tree());
-								if (isobus::VirtualTerminalObjectType::NumberVariable == child->get_object_type())
-								{
-									auto child = clickedList->get_object_by_id(clickedList->get_variable_reference(), parentWorkingSet->get_object_tree());
+								auto referencedVariable = clickedList->get_object_by_id(clickedList->get_variable_reference(), parentWorkingSet->get_object_tree());
 
-									if (nullptr != child)
+								if (nullptr != referencedVariable)
+								{
+									if (isobus::VirtualTerminalObjectType::NumberVariable == referencedVariable->get_object_type())
 									{
-										if (isobus::VirtualTerminalObjectType::NumberVariable == child->get_object_type())
-										{
-											selectedIndex = std::static_pointer_cast<isobus::NumberVariable>(child)->get_value();
-										}
+										selectedIndex = std::static_pointer_cast<isobus::NumberVariable>(referencedVariable)->get_value();
 									}
 								}
 							}

--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -186,7 +186,7 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 							auto combo = inputListModal->getComboBoxComponent("Input List Combo");
 							auto comboPopup = combo->getRootMenu();
 
-							auto selectedIndex = -1;
+							auto selectedIndex = clickedList->get_value();
 
 							if (clickedList->get_variable_reference() != isobus::NULL_OBJECT_ID)
 							{


### PR DESCRIPTION
I came across some input list implementations where the variable reference was not set.
The terminal crashed when selected them. 
With this change the crash is eliminated and the input works as expected.