### PR TITLE
Trigger repaint on InputList selection

### DIFF
--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -274,6 +274,7 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 								}
 								this->inputListModal->exitModalState();
 								parentWorkingSet->set_object_focus(isobus::NULL_OBJECT_ID);
+								ownerServer.onRepaintEventDispatcher.call(parentWorkingSet);
 								ownerServer.process_macro(clickedList, isobus::EventID::OnInputFieldDeselection, isobus::VirtualTerminalObjectType::InputList, parentWorkingSet);
 								inputListModal.reset();
 								repaint();


### PR DESCRIPTION
I came across an issue with an implement where one input list component did not get updated after selection a new value, however others worked fine.

![kép](https://github.com/user-attachments/assets/5db3a1c7-c009-40b3-9d2c-4449c2a46f28)

It turned out that the difference was the fact that for the working input lists the repaint was triggered by an additional Numeric value change reported by the implement, while such a change was not happen after the problematic one.


