### PR TITLE
Fix compilation issue from #51

### DIFF
--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -274,7 +274,7 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 								}
 								this->inputListModal->exitModalState();
 								parentWorkingSet->set_object_focus(isobus::NULL_OBJECT_ID);
-								ownerServer.onRepaintEventDispatcher.call(parentWorkingSet);
+								ownerServer.repaint_on_next_update();
 								ownerServer.process_macro(clickedList, isobus::EventID::OnInputFieldDeselection, isobus::VirtualTerminalObjectType::InputList, parentWorkingSet);
 								inputListModal.reset();
 								repaint();


### PR DESCRIPTION
Instead of trying to access the protected event dispatcher for repaint events, just call the function that event dispatcher calls.