### PR TITLE
Set proper value in number input when the range constrains applied

### DIFF
--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -320,7 +320,7 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 							inputNumberSlider->setValue(scaledValue, NotificationType::dontSendNotification);
 							inputNumberSlider->setSize(400, 80);
 
-							inputNumberListener.set_last_value(clickedNumber->get_value());
+							inputNumberListener.set_last_value(inputNumberSlider->getValue());
 							inputNumberListener.set_target(clickedNumber);
 							inputNumberSlider->addListener(&inputNumberListener);
 


### PR DESCRIPTION
I had an input number which had value of 0 and the minimum and maximum was set to 1.
I could not set the value of this input even if the value was set to 1 in the input number dialog.
Setting the min/max constrained value as a last value of the input number dialog solved this issue. 