### PR TITLE
Add support for alarm acknowledge key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,8 @@ target_sources(
           "src/ConfigureHardwareWindow.cpp"
           "src/ConfigureHardwareComponent.cpp"
           "src/StringEncodingConversions.cpp"
-          "src/InputListComponent.cpp")
+          "src/InputListComponent.cpp"
+          "src/ShortcutsWindow.cpp")
 
 
 target_include_directories(AgISOVirtualTerminal

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -172,8 +172,11 @@ private:
 	AudioDeviceManager mAudioDeviceManager;
 	std::unique_ptr<AlertWindow> popupMenu;
 	std::unique_ptr<ConfigureHardwareWindow> configureHardwareWindow;
+	std::shared_ptr<isobus::ControlFunction> alarmAckKeyWs;
 	std::vector<std::shared_ptr<isobus::CANHardwarePlugin>> &parentCANDrivers;
 	std::vector<HeldButtonData> heldButtons;
+	std::uint32_t alarmAckKeyMaskId = isobus::NULL_OBJECT_ID;
+	int alarmAckKeyCode = juce::KeyPress::escapeKey;
 	std::uint8_t numberOfPoolsToRender = 0;
 	std::uint8_t numberPhysicalSoftKeys = 6;
 	std::uint8_t numberVirtualSoftKeys = 64;
@@ -183,11 +186,7 @@ private:
 	bool needToRepaint = false;
 	bool autostart = false;
 	bool hasStartBeenCalled = false;
-
-	int alarmAckKeyCode = juce::KeyPress::escapeKey;
 	bool alarmAckKeyPressed = false;
-	std::uint32_t alarmAckKeyMaskId = isobus::NULL_OBJECT_ID;
-	std::shared_ptr<isobus::ControlFunction> alarmAckKeyWs;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ServerMainComponent)
 };

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 
 class ServerMainComponent : public juce::Component
+  , public juce::KeyListener
   , public isobus::VirtualTerminalServer
   , public Timer
   , public ApplicationCommandTarget
@@ -34,6 +35,9 @@ public:
 	                                                     std::uint16_t lastWideCharInInquiryRange,
 	                                                     std::uint8_t &numberOfRanges,
 	                                                     std::vector<std::uint8_t> &wideCharRangeArray) override;
+
+	bool keyPressed(const juce::KeyPress &key, juce::Component *originatingComponent) override;
+	bool keyStateChanged(bool isKeyDown, juce::Component *originatingComponent) override;
 
 	std::vector<std::array<std::uint8_t, 7>> get_versions(isobus::NAME clientNAME) override;
 	std::vector<std::uint8_t> get_supported_objects() const override;
@@ -115,6 +119,7 @@ private:
 		ConfigureReportedVersion,
 		ConfigureReportedHardware,
 		ConfigureLogging,
+		ConfigureShortcuts,
 		GenerateLogPackage,
 		ClearISOData,
 		ConfigureCANHardware,
@@ -178,6 +183,11 @@ private:
 	bool needToRepaint = false;
 	bool autostart = false;
 	bool hasStartBeenCalled = false;
+
+	int alarmAckKeyCode = juce::KeyPress::escapeKey;
+	bool alarmAckKeyPressed = false;
+	std::uint32_t alarmAckKeyMaskId = isobus::NULL_OBJECT_ID;
+	std::shared_ptr<isobus::ControlFunction> alarmAckKeyWs;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ServerMainComponent)
 };

--- a/include/ShortcutsWindow.hpp
+++ b/include/ShortcutsWindow.hpp
@@ -14,21 +14,21 @@ class ShortcutsWindow : public juce::AlertWindow
   , public juce::KeyListener
 {
 public:
-	ShortcutsWindow(int currentKeyCode, Component *associatedComponent = nullptr);
+	ShortcutsWindow(int alarmAckKeyCode, Component *associatedComponent = nullptr);
 
 	void resized() override;
 	bool keyPressed(const juce::KeyPress &key, juce::Component *originatingComponent) override;
-	int selectedKeyCode() const;
+	int alarmAckKeyCode() const;
 
 private:
-	juce::TextButton selectKeyButton;
-	int selectedKeyCode_ = juce::KeyPress::escapeKey;
+	juce::TextButton selectAlarmAckKeyButton;
+	int alarmAckKey = juce::KeyPress::escapeKey;
 
 	bool keySelectionMode = false;
 
 	void updateAlarmAckButtonLabel(const juce::KeyPress &key);
 
-	void setKeySelectionMode(bool isEnabled);
+	void setAlarmAckKeySelection(bool isEnabled);
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ShortcutsWindow)
 };

--- a/include/ShortcutsWindow.hpp
+++ b/include/ShortcutsWindow.hpp
@@ -1,0 +1,34 @@
+//================================================================================================
+/// @file ShortcutsWindow.hpp
+///
+/// @brief Defines a dialog where keyboard shortcuts could be selected
+/// @author Miklos Marton
+///
+/// @copyright The Open-Agriculture Developers
+//================================================================================================
+#pragma once
+
+#include "JuceHeader.h"
+
+class ShortcutsWindow : public juce::AlertWindow
+  , public juce::KeyListener
+{
+public:
+	ShortcutsWindow(int currentKeyCode, Component *associatedComponent = nullptr);
+
+	void resized() override;
+	bool keyPressed(const juce::KeyPress &key, juce::Component *originatingComponent) override;
+	int selectedKeyCode() const;
+
+private:
+	juce::TextButton selectKeyButton;
+	int selectedKeyCode_ = juce::KeyPress::escapeKey;
+
+	bool keySelectionMode = false;
+
+	void updateAlarmAckButtonLabel(const juce::KeyPress &key);
+
+	void setKeySelectionMode(bool isEnabled);
+
+	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ShortcutsWindow)
+};

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -1225,7 +1225,7 @@ void ServerMainComponent::LanguageCommandConfigClosed::operator()(int result) co
 
 		case 5: // Shortcuts
 		{
-			mParent.alarmAckKeyCode = dynamic_cast<ShortcutsWindow *>(mParent.popupMenu.get())->selectedKeyCode();
+			mParent.alarmAckKeyCode = dynamic_cast<ShortcutsWindow *>(mParent.popupMenu.get())->alarmAckKeyCode();
 			mParent.save_settings();
 		}
 

--- a/src/ShortcutsWindow.cpp
+++ b/src/ShortcutsWindow.cpp
@@ -5,57 +5,57 @@
 *******************************************************************************/
 #include "ShortcutsWindow.hpp"
 
-ShortcutsWindow::ShortcutsWindow(int currentKeyCode, Component *associatedComponent) :
+ShortcutsWindow::ShortcutsWindow(int alarmAckKeyCode, Component *associatedComponent) :
   juce::AlertWindow("Keyboard shortcuts", "", MessageBoxIconType::NoIcon, associatedComponent),
-  selectedKeyCode_(currentKeyCode)
+  alarmAckKey(alarmAckKeyCode)
 {
-	juce::KeyPress key(currentKeyCode);
-	addCustomComponent(&selectKeyButton);
-	selectKeyButton.onClick = [this]() { setKeySelectionMode(true); };
-	updateAlarmAckButtonLabel(key);
+	juce::KeyPress alarmAckKey(alarmAckKeyCode);
+	addCustomComponent(&selectAlarmAckKeyButton);
+	selectAlarmAckKeyButton.onClick = [this]() { setAlarmAckKeySelection(true); };
+	updateAlarmAckButtonLabel(alarmAckKey);
 
 	addButton("OK", 5, KeyPress(KeyPress::returnKey, 0, 0));
 	addButton("Cancel", 0);
 
-	setKeySelectionMode(false);
+	setAlarmAckKeySelection(false);
 }
 
 void ShortcutsWindow::resized()
 {
 	auto area = getLocalBounds();
 	auto customArea = area.removeFromTop(40).removeFromLeft(area.getWidth() / 1.2);
-	selectKeyButton.setBounds(customArea);
+	selectAlarmAckKeyButton.setBounds(customArea);
 }
 
 bool ShortcutsWindow::keyPressed(const KeyPress &key, Component *originatingComponent)
 {
 	if (keySelectionMode)
 	{
-		selectedKeyCode_ = key.getKeyCode();
-		setKeySelectionMode(false);
+		alarmAckKey = key.getKeyCode();
+		setAlarmAckKeySelection(false);
 		updateAlarmAckButtonLabel(key);
 		return true;
 	}
 	return false;
 }
 
-int ShortcutsWindow::selectedKeyCode() const
+int ShortcutsWindow::alarmAckKeyCode() const
 {
-	return selectedKeyCode_;
+	return alarmAckKey;
 }
 
 void ShortcutsWindow::updateAlarmAckButtonLabel(const KeyPress &key)
 {
-	selectKeyButton.setButtonText("Alarm acknowledge key: " + key.getTextDescription());
+	selectAlarmAckKeyButton.setButtonText("Alarm acknowledge key: " + key.getTextDescription());
 }
 
-void ShortcutsWindow::setKeySelectionMode(bool isEnabled)
+void ShortcutsWindow::setAlarmAckKeySelection(bool isEnabled)
 {
 	keySelectionMode = isEnabled;
-	selectKeyButton.setEnabled(!isEnabled);
+	selectAlarmAckKeyButton.setEnabled(!isEnabled);
 	if (isEnabled)
 	{
-		selectKeyButton.setButtonText("Alarm acknowledge key: press one key...");
+		selectAlarmAckKeyButton.setButtonText("Alarm acknowledge key: press one key...");
 
 		setWantsKeyboardFocus(true);
 		addKeyListener(this);

--- a/src/ShortcutsWindow.cpp
+++ b/src/ShortcutsWindow.cpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+** @file       ShortcutsWindow.cpp
+** @author     Miklos Marton
+** @copyright  The Open-Agriculture Developers
+*******************************************************************************/
+#include "ShortcutsWindow.hpp"
+
+ShortcutsWindow::ShortcutsWindow(int currentKeyCode, Component *associatedComponent) :
+  juce::AlertWindow("Keyboard shortcuts", "", MessageBoxIconType::NoIcon, associatedComponent),
+  selectedKeyCode_(currentKeyCode)
+{
+	juce::KeyPress key(currentKeyCode);
+	addCustomComponent(&selectKeyButton);
+	selectKeyButton.onClick = [this]() { setKeySelectionMode(true); };
+	updateAlarmAckButtonLabel(key);
+
+	addButton("OK", 5, KeyPress(KeyPress::returnKey, 0, 0));
+	addButton("Cancel", 0);
+
+	setKeySelectionMode(false);
+}
+
+void ShortcutsWindow::resized()
+{
+	auto area = getLocalBounds();
+	auto customArea = area.removeFromTop(40).removeFromLeft(area.getWidth() / 1.2);
+	selectKeyButton.setBounds(customArea);
+}
+
+bool ShortcutsWindow::keyPressed(const KeyPress &key, Component *originatingComponent)
+{
+	if (keySelectionMode)
+	{
+		selectedKeyCode_ = key.getKeyCode();
+		setKeySelectionMode(false);
+		updateAlarmAckButtonLabel(key);
+		return true;
+	}
+	return false;
+}
+
+int ShortcutsWindow::selectedKeyCode() const
+{
+	return selectedKeyCode_;
+}
+
+void ShortcutsWindow::updateAlarmAckButtonLabel(const KeyPress &key)
+{
+	selectKeyButton.setButtonText("Alarm acknowledge key: " + key.getTextDescription());
+}
+
+void ShortcutsWindow::setKeySelectionMode(bool isEnabled)
+{
+	keySelectionMode = isEnabled;
+	selectKeyButton.setEnabled(!isEnabled);
+	if (isEnabled)
+	{
+		selectKeyButton.setButtonText("Alarm acknowledge key: press one key...");
+
+		setWantsKeyboardFocus(true);
+		addKeyListener(this);
+		grabKeyboardFocus();
+	}
+	else
+	{
+		setWantsKeyboardFocus(false);
+		removeKeyListener(this);
+		if (hasKeyboardFocus(false))
+			giveAwayKeyboardFocus();
+	}
+}


### PR DESCRIPTION
This PR add support for configuring a custom keyboard shortcut to send alarm acknowledge message. See #58.