### PR TITLE
Fix repaint missing updated content because of overriding update flag 

### DIFF
--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -15,6 +15,7 @@ DataMaskRenderAreaComponent::DataMaskRenderAreaComponent(ServerMainComponent &pa
 
 void DataMaskRenderAreaComponent::on_change_active_mask(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet)
 {
+	needToRepaintActiveArea = false;
 	childComponents.clear();
 	parentWorkingSet = workingSet;
 
@@ -27,7 +28,6 @@ void DataMaskRenderAreaComponent::on_change_active_mask(std::shared_ptr<isobus::
 		addAndMakeVisible(*childComponents.back());
 	}
 	repaint();
-	needToRepaintActiveArea = false;
 }
 
 void DataMaskRenderAreaComponent::on_working_set_disconnect(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet)

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -529,15 +529,10 @@ void ServerMainComponent::timerCallback()
 		}
 		else if (isobus::VirtualTerminalServerManagedWorkingSet::ObjectPoolProcessingThreadState::Joined == ws->get_object_pool_processing_state())
 		{
-			if (dataMaskRenderer.needsRepaint())
+			if (dataMaskRenderer.needsRepaint() || needToRepaint)
 			{
-				repaint_data_and_soft_key_mask();
 				needToRepaint = false;
-			}
-			else if (needToRepaint)
-			{
 				repaint_data_and_soft_key_mask();
-				needToRepaint = false;
 			}
 
 			for (auto &heldButton : heldButtons)


### PR DESCRIPTION
Basically we are currently setting the flag **after** the content has been updated. But because of multi-threaded environment, we find that between the time the flag was checked, and the time it was set to `false` after the repaint, there could've been a content change. This content change will be overridden by the set to `false` **after** the initial repaint. Meaning the second needed repaint get's skipped while in fact it was very much needed to reflect the latest changes.

I hope this makes sense, it probably can be understood better with a visualization. Let me know if anyone wants that for a better explanation. 😃 