### PR TITLE
Add NULL check to wokring set change due to working set disappearance

### DIFF
--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -545,8 +545,16 @@ void ServerMainComponent::timerCallback()
 					if (nextWorkingSet->get_control_function()->get_address() != activeWorkingSetMasterAddress)
 					{
 						activeWorkingSetMasterAddress = nextWorkingSet->get_control_function()->get_address();
-						activeWorkingSetDataMaskObjectID = std::static_pointer_cast<isobus::WorkingSet>(nextWorkingSet->get_working_set_object())->get_active_mask();
-						newWorkingSetFound = true;
+						if (nextWorkingSet->get_working_set_object())
+						{
+							activeWorkingSetDataMaskObjectID = std::static_pointer_cast<isobus::WorkingSet>(nextWorkingSet->get_working_set_object())->get_active_mask();
+							newWorkingSetFound = true;
+						}
+						else
+						{
+							activeWorkingSetDataMaskObjectID = isobus::NULL_OBJECT_ID;
+							newWorkingSetFound = false;
+						}
 						break;
 					}
 				}


### PR DESCRIPTION
I have managed to trigger a crash while one of my implements timed out. 
Added NULL check to prevent this.