### PR TITLE
Fix issues with button press on softkey change

### DIFF
--- a/include/KeyComponent.hpp
+++ b/include/KeyComponent.hpp
@@ -21,8 +21,13 @@ public:
 	KeyComponent(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, isobus::Key sourceObject, int keyWidth, int keyHeight);
 
 	void paint(Graphics &g) override;
+	void setKeyPosition(uint8_t pos);
+	std::uint8_t getKeyPosition() const;
+
+	static inline constexpr std::uint8_t InvalidSoftKeyPos = 255;
 
 private:
+	std::uint8_t keyPosition = InvalidSoftKeyPos;
 	std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> parentWorkingSet;
 	std::vector<std::shared_ptr<Component>> childComponents;
 

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -2,6 +2,7 @@
 
 #include "ConfigureHardwareWindow.hpp"
 #include "DataMaskRenderAreaComponent.hpp"
+#include "KeyComponent.hpp"
 #include "LoggerComponent.hpp"
 #include "SoftKeyMaskComponent.hpp"
 #include "SoftKeyMaskRenderAreaComponent.hpp"
@@ -195,14 +196,6 @@ private:
 	void remove_working_set(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSetToRemove);
 	void clear_iso_data();
 
-	/**
-	 * @brief get_softkey_index_on_softkey_mask
-	 * @param keyID ID of the key to be queried
-	 * @return The 0 based child index of the key specified by the keyID in the active softkey mask or
-	 * KeyComponent::InvalidSoftKeyPos (255) if the specified key is not part of the current softkey mask
-	 */
-	std::uint8_t get_softkey_index_on_softkey_mask(std::uint16_t keyID);
-
 	const std::string ISO_DATA_PATH = "iso_data";
 	std::string screenCaptureDirArgument = "";
 	std::string canLogPath;
@@ -228,7 +221,7 @@ private:
 	std::uint32_t alarmAckKeyMaskId = isobus::NULL_OBJECT_ID;
 	int alarmAckKeyCode = juce::KeyPress::escapeKey;
 	std::uint8_t vtNumber = 1; // VT number in the range of 1-32
-	std::uint8_t softKeyPositionReleasedByMaskChange;
+	std::uint8_t softKeyPositionReleasedByMaskChange = KeyComponent::InvalidSoftKeyPos;
 	std::uint8_t numberOfPoolsToRender = 0;
 	VTVersion versionToReport = VTVersion::Version5;
 	bool needToRepaint = false;

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -177,7 +177,7 @@ private:
 		std::uint16_t buttonObjectID;
 		std::uint16_t activeMaskObjectID;
 		std::uint8_t buttonKeyCode;
-		std::uint8_t keyPosition; // applicable only for softkeys
+		std::uint8_t keyPosition = KeyComponent::InvalidSoftKeyPos; // applicable only for softkeys used for release tracking
 		bool isSoftKey;
 	};
 

--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -6,6 +6,7 @@
 #include "DataMaskRenderAreaComponent.hpp"
 #include "AppImages.h"
 #include "JuceManagedWorkingSetCache.hpp"
+#include "KeyComponent.hpp"
 #include "ServerMainComponent.hpp"
 
 DataMaskRenderAreaComponent::DataMaskRenderAreaComponent(ServerMainComponent &parentServer) :
@@ -79,10 +80,11 @@ void DataMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 			auto relativeEvent = event.getEventRelativeTo(this);
 			auto clickedObject = getClickedChildRecursive(activeMask, relativeEvent.getMouseDownX(), relativeEvent.getMouseDownY());
 
-			std::uint8_t keyCode = 1;
-
 			if (nullptr != clickedObject)
 			{
+				std::uint8_t keyCode = 1;
+				std::uint8_t keyPos = KeyComponent::InvalidSoftKeyPos;
+
 				if (isobus::VirtualTerminalObjectType::Button == clickedObject->get_object_type())
 				{
 					keyCode = std::static_pointer_cast<isobus::Button>(clickedObject)->get_key_code();
@@ -91,6 +93,7 @@ void DataMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 				else if (isobus::VirtualTerminalObjectType::Key == clickedObject->get_object_type())
 				{
 					keyCode = std::static_pointer_cast<isobus::Key>(clickedObject)->get_key_code();
+					keyPos = std::static_pointer_cast<KeyComponent>(clickedObject)->getKeyPosition();
 					ownerServer.process_macro(clickedObject, isobus::EventID::OnKeyPress, isobus::VirtualTerminalObjectType::Key, parentWorkingSet);
 				}
 
@@ -106,7 +109,8 @@ void DataMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 					                            clickedObject->get_id(),
 					                            activeMask->get_id(),
 					                            keyCode,
-					                            (isobus::VirtualTerminalObjectType::Key == clickedObject->get_object_type()));
+					                            (isobus::VirtualTerminalObjectType::Key == clickedObject->get_object_type()),
+					                            keyPos);
 				}
 			}
 		}
@@ -149,7 +153,8 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 							                                clickedObject->get_id(),
 							                                activeMask->get_id(),
 							                                keyCode,
-							                                true);
+							                                true,
+							                                KeyComponent::InvalidSoftKeyPos);
 						}
 					}
 					break;
@@ -157,6 +162,7 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 					case isobus::VirtualTerminalObjectType::Key:
 					{
 						keyCode = std::static_pointer_cast<isobus::Key>(clickedObject)->get_key_code();
+						std::uint8_t keyPos = std::static_pointer_cast<KeyComponent>(clickedObject)->getKeyPosition();
 						ownerServer.send_button_activation_message(isobus::VirtualTerminalBase::KeyActivationCode::ButtonUnlatchedOrReleased,
 						                                           clickedObject->get_id(),
 						                                           activeMask->get_id(),
@@ -167,7 +173,8 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 						                                clickedObject->get_id(),
 						                                activeMask->get_id(),
 						                                keyCode,
-						                                true);
+						                                true,
+						                                keyPos);
 					}
 					break;
 

--- a/src/KeyComponent.cpp
+++ b/src/KeyComponent.cpp
@@ -37,3 +37,13 @@ void KeyComponent::paint(Graphics &g)
 
 	g.fillAll(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0f));
 }
+
+uint8_t KeyComponent::getKeyPosition() const
+{
+	return keyPosition;
+}
+
+void KeyComponent::setKeyPosition(std::uint8_t pos)
+{
+	keyPosition = pos;
+}

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -2090,23 +2090,3 @@ std::string ServerMainComponent::getAppDataDir()
 {
 	return juce::String(File::getSpecialLocation(File::userApplicationDataDirectory).getFullPathName() + File::getSeparatorString() + "Open-Agriculture").toStdString();
 }
-
-uint8_t ServerMainComponent::get_softkey_index_on_softkey_mask(uint16_t keyID)
-{
-	auto object = activeWorkingSet->get_object_by_id(activeWorkingSetSoftkeyMaskObjectID);
-	if (nullptr != object && isobus::VirtualTerminalObjectType::SoftKeyMask == object->get_object_type())
-	{
-		for (int i = 0; i < object->get_number_children(); i++)
-		{
-			auto child = object->get_object_by_id(object->get_child_id(i), activeWorkingSet->get_object_tree());
-			if (nullptr != child && isobus::VirtualTerminalObjectType::Key == object->get_object_type())
-			{
-				if (object->get_child_id(i) == keyID)
-				{
-					return i;
-				}
-			}
-		}
-	}
-	return KeyComponent::InvalidSoftKeyPos;
-}

--- a/src/SoftKeyMaskComponent.cpp
+++ b/src/SoftKeyMaskComponent.cpp
@@ -36,9 +36,9 @@ void SoftKeyMaskComponent::on_content_changed(bool initial)
 			{
 				childComponents.back()->setSize(dimensionInfo.keyWidth, dimensionInfo.keyHeight);
 				auto keyReference = get_object_by_id(std::static_pointer_cast<ObjectPointerComponent>(childComponents.back())->get_value(), parentWorkingSet->get_object_tree());
-				if (nullptr != keyReference && isobus::VirtualTerminalObjectType::Key == child->get_object_type())
+				if (nullptr != keyReference && isobus::VirtualTerminalObjectType::Key == keyReference->get_object_type())
 				{
-					std::static_pointer_cast<KeyComponent>(childComponents.back())->setKeyPosition(i);
+					std::static_pointer_cast<KeyComponent>(keyReference)->setKeyPosition(i);
 				}
 			}
 			else if (isobus::VirtualTerminalObjectType::Key == child->get_object_type())

--- a/src/SoftKeyMaskComponent.cpp
+++ b/src/SoftKeyMaskComponent.cpp
@@ -5,8 +5,8 @@
 *******************************************************************************/
 #include "SoftKeyMaskComponent.hpp"
 #include "JuceManagedWorkingSetCache.hpp"
-
-#include "SoftKeyMaskRenderAreaComponent.hpp"
+#include "KeyComponent.hpp"
+#include "ObjectPointerComponent.hpp"
 
 SoftKeyMaskComponent::SoftKeyMaskComponent(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, isobus::SoftKeyMask sourceObject, SoftKeyMaskDimensions dimensions) :
   isobus::SoftKeyMask(sourceObject),
@@ -35,6 +35,15 @@ void SoftKeyMaskComponent::on_content_changed(bool initial)
 			if (isobus::VirtualTerminalObjectType::ObjectPointer == child->get_object_type())
 			{
 				childComponents.back()->setSize(dimensionInfo.keyWidth, dimensionInfo.keyHeight);
+				auto keyReference = get_object_by_id(std::static_pointer_cast<ObjectPointerComponent>(childComponents.back())->get_value(), parentWorkingSet->get_object_tree());
+				if (nullptr != keyReference && isobus::VirtualTerminalObjectType::Key == child->get_object_type())
+				{
+					std::static_pointer_cast<KeyComponent>(childComponents.back())->setKeyPosition(i);
+				}
+			}
+			else if (isobus::VirtualTerminalObjectType::Key == child->get_object_type())
+			{
+				std::static_pointer_cast<KeyComponent>(childComponents.back())->setKeyPosition(i);
 			}
 
 			if (nullptr != childComponents.back())

--- a/src/SoftkeyMaskRenderArea.cpp
+++ b/src/SoftkeyMaskRenderArea.cpp
@@ -182,6 +182,7 @@ void SoftKeyMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 				{
 					keyCode = std::static_pointer_cast<isobus::Key>(clickedObject)->get_key_code();
 					keyPosition = std::static_pointer_cast<KeyComponent>(clickedObject)->getKeyPosition();
+					jassert(keyPosition != KeyComponent::InvalidSoftKeyPos);
 				}
 				// TODO for VT4 / key group support we will need to pass the object ID of the key group object, not the active data/alarm mask ID
 				//

--- a/src/SoftkeyMaskRenderArea.cpp
+++ b/src/SoftkeyMaskRenderArea.cpp
@@ -4,6 +4,7 @@
 ** @copyright  The Open-Agriculture Developers
 *******************************************************************************/
 #include "JuceManagedWorkingSetCache.hpp"
+#include "KeyComponent.hpp"
 #include "ServerMainComponent.hpp"
 #include "SoftKeyMaskRenderAreaComponent.hpp"
 
@@ -83,52 +84,54 @@ void SoftKeyMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 
 		if (nullptr != workingSetObject)
 		{
-			auto activeMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
-			auto parentMask = activeMask;
+			auto activeDataOrAlarmMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
+			std::shared_ptr<isobus::VTObject> softKeyMask = nullptr;
 
-			if (isobus::VirtualTerminalObjectType::AlarmMask == activeMask->get_object_type())
+			if (isobus::VirtualTerminalObjectType::AlarmMask == activeDataOrAlarmMask->get_object_type())
 			{
-				auto child = activeMask->get_object_by_id(std::static_pointer_cast<isobus::AlarmMask>(activeMask)->get_soft_key_mask(), parentWorkingSet->get_object_tree());
+				auto child = activeDataOrAlarmMask->get_object_by_id(std::static_pointer_cast<isobus::AlarmMask>(activeDataOrAlarmMask)->get_soft_key_mask(), parentWorkingSet->get_object_tree());
 
 				if ((nullptr != child) && (isobus::VirtualTerminalObjectType::SoftKeyMask == child->get_object_type()))
 				{
-					activeMask = child;
+					softKeyMask = child;
 				}
 			}
-			else if (isobus::VirtualTerminalObjectType::DataMask == activeMask->get_object_type())
+			else if (isobus::VirtualTerminalObjectType::DataMask == activeDataOrAlarmMask->get_object_type())
 			{
-				auto child = activeMask->get_object_by_id(std::static_pointer_cast<isobus::DataMask>(activeMask)->get_soft_key_mask(), parentWorkingSet->get_object_tree());
+				auto child = activeDataOrAlarmMask->get_object_by_id(std::static_pointer_cast<isobus::DataMask>(activeDataOrAlarmMask)->get_soft_key_mask(), parentWorkingSet->get_object_tree());
 
 				if ((nullptr != child) && (isobus::VirtualTerminalObjectType::SoftKeyMask == child->get_object_type()))
 				{
-					activeMask = child;
+					softKeyMask = child;
 				}
 			}
 
 			auto relativeEvent = event.getEventRelativeTo(this);
-			auto clickedObject = getClickedChildRecursive(activeMask, relativeEvent.getMouseDownX(), relativeEvent.getMouseDownY());
+			auto clickedObject = getClickedChildRecursive(softKeyMask, relativeEvent.getMouseDownX(), relativeEvent.getMouseDownY());
 
 			ownerServer.process_macro(clickedObject, isobus::EventID::OnKeyPress, isobus::VirtualTerminalObjectType::Key, parentWorkingSet);
 
-			std::uint8_t keyCode = 1;
-
 			if (nullptr != clickedObject)
 			{
+				std::uint8_t keyCode = 1;
+				std::uint8_t keyPositon = KeyComponent::InvalidSoftKeyPos;
 				if (isobus::VirtualTerminalObjectType::Key == clickedObject->get_object_type())
 				{
 					keyCode = std::static_pointer_cast<isobus::Key>(clickedObject)->get_key_code();
+					keyPositon = std::static_pointer_cast<KeyComponent>(clickedObject)->getKeyPosition();
 				}
 
 				ownerServer.send_soft_key_activation_message(isobus::VirtualTerminalBase::KeyActivationCode::ButtonPressedOrLatched,
 				                                             clickedObject->get_id(),
-				                                             parentMask->get_id(),
+				                                             activeDataOrAlarmMask->get_id(),
 				                                             keyCode,
 				                                             ownerServer.get_active_working_set()->get_control_function());
 				ownerServer.set_button_held(ownerServer.get_active_working_set(),
 				                            clickedObject->get_id(),
-				                            activeMask->get_id(),
+				                            activeDataOrAlarmMask->get_id(),
 				                            keyCode,
-				                            true);
+				                            true,
+				                            keyPositon);
 			}
 		}
 	}
@@ -143,52 +146,61 @@ void SoftKeyMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 
 		if (nullptr != workingSetObject)
 		{
-			auto activeMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
-			auto parentMask = activeMask;
+			auto activeDataOrAlarmMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
+			std::shared_ptr<isobus::VTObject> softKeyMask;
 
-			if (isobus::VirtualTerminalObjectType::AlarmMask == activeMask->get_object_type())
+			if (isobus::VirtualTerminalObjectType::AlarmMask == activeDataOrAlarmMask->get_object_type())
 			{
-				auto child = activeMask->get_object_by_id(std::static_pointer_cast<isobus::AlarmMask>(activeMask)->get_soft_key_mask(), parentWorkingSet->get_object_tree());
+				auto child = activeDataOrAlarmMask->get_object_by_id(std::static_pointer_cast<isobus::AlarmMask>(activeDataOrAlarmMask)->get_soft_key_mask(), parentWorkingSet->get_object_tree());
 
 				if ((nullptr != child) && (isobus::VirtualTerminalObjectType::SoftKeyMask == child->get_object_type()))
 				{
-					activeMask = child;
+					softKeyMask = child;
 				}
 			}
-			else if (isobus::VirtualTerminalObjectType::DataMask == activeMask->get_object_type())
+			else if (isobus::VirtualTerminalObjectType::DataMask == activeDataOrAlarmMask->get_object_type())
 			{
-				auto child = activeMask->get_object_by_id(std::static_pointer_cast<isobus::DataMask>(activeMask)->get_soft_key_mask(), parentWorkingSet->get_object_tree());
+				auto child = activeDataOrAlarmMask->get_object_by_id(std::static_pointer_cast<isobus::DataMask>(activeDataOrAlarmMask)->get_soft_key_mask(), parentWorkingSet->get_object_tree());
 
 				if ((nullptr != child) && (isobus::VirtualTerminalObjectType::SoftKeyMask == child->get_object_type()))
 				{
-					activeMask = child;
+					softKeyMask = child;
 				}
 			}
 
 			auto relativeEvent = event.getEventRelativeTo(this);
-			auto clickedObject = getClickedChildRecursive(activeMask, relativeEvent.getPosition().x, relativeEvent.getPosition().y);
+			auto clickedObject = getClickedChildRecursive(softKeyMask, relativeEvent.getPosition().x, relativeEvent.getPosition().y);
 
 			ownerServer.process_macro(clickedObject, isobus::EventID::OnKeyRelease, isobus::VirtualTerminalObjectType::Key, parentWorkingSet);
 
 			std::uint8_t keyCode = 1;
+			std::uint8_t keyPosition = KeyComponent::InvalidSoftKeyPos;
 
 			if (nullptr != clickedObject)
 			{
 				if (isobus::VirtualTerminalObjectType::Key == clickedObject->get_object_type())
 				{
 					keyCode = std::static_pointer_cast<isobus::Key>(clickedObject)->get_key_code();
+					keyPosition = std::static_pointer_cast<KeyComponent>(clickedObject)->getKeyPosition();
 				}
-
-				ownerServer.send_soft_key_activation_message(isobus::VirtualTerminalBase::KeyActivationCode::ButtonUnlatchedOrReleased,
-				                                             clickedObject->get_id(),
-				                                             parentMask->get_id(),
-				                                             keyCode,
-				                                             ownerServer.get_active_working_set()->get_control_function());
+				// TODO for VT4 / key group support we will need to pass the object ID of the key group object, not the active data/alarm mask ID
+				//
+				// Parent object ID field:
+				// Object ID of visible Data Mask, Alarm Mask, or in the case where the Soft Key is in a visible Key Group, the Object ID of the Key Group Object
+				if (!ownerServer.is_key_position_released_by_mask_change(keyPosition))
+				{
+					ownerServer.send_soft_key_activation_message(isobus::VirtualTerminalBase::KeyActivationCode::ButtonUnlatchedOrReleased,
+					                                             clickedObject->get_id(),
+					                                             activeDataOrAlarmMask->get_id(),
+					                                             keyCode,
+					                                             ownerServer.get_active_working_set()->get_control_function());
+				}
 				ownerServer.set_button_released(ownerServer.get_active_working_set(),
 				                                clickedObject->get_id(),
-				                                activeMask->get_id(),
+				                                activeDataOrAlarmMask->get_id(),
 				                                keyCode,
-				                                true);
+				                                true,
+				                                keyPosition);
 			}
 		}
 	}


### PR DESCRIPTION
In the case if a softkey press triggered a softkey mask change then the button still held messages kept sending forever.

The reason behind this behavior is the following: the button receieved the mouseUp event, added the pressed state to the held buttons list. 

The button got removed by the softkeymask change so the mouseRelease event was not called at all on the clicked softkey. However after the actual release of the mouse key the release event for the new button is sent. 

The standard says that on softkey mask change the key should send a release event and ignore the key until it released. 

The same applies to the buttons on the datamask (on datamask change) but I would like to address that in a separate PR.