### PR TITLE
Do not display string variables after \0

### DIFF
--- a/src/OutputStringComponent.cpp
+++ b/src/OutputStringComponent.cpp
@@ -19,7 +19,7 @@ void OutputStringComponent::paint(Graphics &g)
 {
 	std::string value = displayed_value(parentWorkingSet);
 
-	size_t pos = value.find('\0');
+	std::size_t pos = value.find('\0');
 	if (pos != std::string::npos)
 	{
 		value = value.substr(0, pos);

--- a/src/OutputStringComponent.cpp
+++ b/src/OutputStringComponent.cpp
@@ -18,6 +18,13 @@ OutputStringComponent::OutputStringComponent(std::shared_ptr<isobus::VirtualTerm
 void OutputStringComponent::paint(Graphics &g)
 {
 	std::string value = displayed_value(parentWorkingSet);
+
+	size_t pos = value.find('\0');
+	if (pos != std::string::npos)
+	{
+		value = value.substr(0, pos);
+	}
+
 	std::uint8_t fontHeight = 0;
 	auto fontType = isobus::FontAttributes::FontType::ISO8859_1;
 


### PR DESCRIPTION
I came across an implement where an erratic macro having a ChangeString command had a bad string length (size was 3 bytes instead of the 1 byte length) and it lead to copying over some memory scrap. This lead to displaying cryptic characters. Other terminals discarded the part starting from the \0 position.