### PR TITLE
Offset Button child components with the border thickness

### DIFF
--- a/cmake/FindCAN_Stack.cmake
+++ b/cmake/FindCAN_Stack.cmake
@@ -3,6 +3,6 @@ if(NOT TARGET isobus::isobus)
   FetchContent_Declare(
     CAN_Stack
     GIT_REPOSITORY https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git
-    GIT_TAG e3a16f2f26698736b58ae05606fc979289ae5354)
+    GIT_TAG a71c186efd189b45759364ddf790b5634b8ba878)
   FetchContent_MakeAvailable(CAN_Stack)
 endif()

--- a/cmake/FindCAN_Stack.cmake
+++ b/cmake/FindCAN_Stack.cmake
@@ -3,6 +3,6 @@ if(NOT TARGET isobus::isobus)
   FetchContent_Declare(
     CAN_Stack
     GIT_REPOSITORY https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git
-    GIT_TAG 4ad80207b5e44d041d8e0fba8ef044367dfbfe86)
+    GIT_TAG e3a16f2f26698736b58ae05606fc979289ae5354)
   FetchContent_MakeAvailable(CAN_Stack)
 endif()

--- a/include/ButtonComponent.hpp
+++ b/include/ButtonComponent.hpp
@@ -24,6 +24,8 @@ public:
 
 	void paintButton(Graphics &g, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) override;
 
+	void set_options(std::uint8_t value) override;
+
 private:
 	std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> parentWorkingSet;
 	std::vector<std::shared_ptr<Component>> childComponents;

--- a/src/ButtonComponent.cpp
+++ b/src/ButtonComponent.cpp
@@ -14,6 +14,8 @@ ButtonComponent::ButtonComponent(std::shared_ptr<isobus::VirtualTerminalServerMa
 	setOpaque(false);
 	setSize(get_width(), get_height());
 
+	auto borderOffset = get_option(Options::NoBorder) ? 0 : 4;
+
 	for (std::uint16_t i = 0; i < this->get_number_children(); i++)
 	{
 		auto child = get_object_by_id(get_child_id(i), parentWorkingSet->get_object_tree());
@@ -25,7 +27,7 @@ ButtonComponent::ButtonComponent(std::shared_ptr<isobus::VirtualTerminalServerMa
 			if (nullptr != childComponents.back())
 			{
 				addAndMakeVisible(*childComponents.back());
-				childComponents.back()->setTopLeftPosition(get_child_x(i), get_child_y(i));
+				childComponents.back()->setTopLeftPosition(get_child_x(i) + borderOffset, get_child_y(i) + borderOffset);
 			}
 		}
 	}
@@ -44,7 +46,7 @@ void ButtonComponent::paint(Graphics &g)
 		g.fillAll(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0f));
 	}
 
-	if (false == get_option(Options::NoBorder))
+	if (false == get_option(Options::NoBorder) && false == get_option(Options::SuppressBorder))
 	{
 		vtColour = parentWorkingSet->get_colour(get_border_colour());
 		g.setColour(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0f));
@@ -54,4 +56,20 @@ void ButtonComponent::paint(Graphics &g)
 
 void ButtonComponent::paintButton(Graphics &, bool, bool)
 {
+}
+
+void ButtonComponent::set_options(uint8_t value)
+{
+	// adjust the position of the childs to the button face area if the NoBorder attribute is changed
+	if ((value & static_cast<uint8_t>(Options::NoBorder)) != get_option(Options::NoBorder))
+	{
+		auto borderOffset = (value & static_cast<uint8_t>(Options::NoBorder)) ? -4 : 4;
+		int i = 0;
+		for (auto &child : childComponents)
+		{
+			child->setTopLeftPosition(get_child_x(i) + borderOffset, get_child_y(i) + borderOffset);
+			i++;
+		}
+	}
+	return isobus::Button::set_options(value);
 }

--- a/src/ButtonComponent.cpp
+++ b/src/ButtonComponent.cpp
@@ -63,7 +63,7 @@ void ButtonComponent::set_options(uint8_t value)
 	// adjust the position of the childs to the button face area if the NoBorder attribute is changed
 	if ((value & static_cast<uint8_t>(Options::NoBorder)) != get_option(Options::NoBorder))
 	{
-		auto borderOffset = (value & static_cast<uint8_t>(Options::NoBorder)) ? -4 : 4;
+		auto borderOffset = (0 != (value & static_cast<uint8_t>(Options::NoBorder))) ? -4 : 4;
 		int i = 0;
 		for (auto &child : childComponents)
 		{


### PR DESCRIPTION
The default border width was not taken into account for positioning child objects resulting weird looking buttons:
![kép](https://github.com/user-attachments/assets/ea346e57-b81d-4a96-afaf-1cbbc43f990c)

Now it looks better:
![kép](https://github.com/user-attachments/assets/93707d5d-3257-469e-b76e-8fcb6948a748)

For reference this is how it looks on a physical terminal:
![kép](https://github.com/user-attachments/assets/6caf539f-0746-4a77-97e0-1a41f8ea0d72)

By inspecting the Kverneland's IsoMatch button drawing more closely I think it would be added value in following their approach for drawing different border for checked/unchecked buttons, but that's the story of an another PR.