### PR TITLE
Add support for Screen Capture command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Supported features:
 - Multiple simultaneous VT clients
 - Selecting different working sets
 - Most common macro and extended macro functionality
+- Screen capture command/response
 
 Unimplemented features (for now - we are always adding new features)
 

--- a/include/Main.hpp
+++ b/include/Main.hpp
@@ -47,6 +47,7 @@ public:
 		args.addTokens(commandLineParameters, true);
 
 		std::uint8_t vtNumber = 0;
+		std::string screenCaptureDir;
 		for (const auto &arg : args)
 		{
 			if (arg.startsWith("--vt-number"))
@@ -58,9 +59,14 @@ public:
 					vtNumber = 0;
 				}
 			}
+
+			if (arg.startsWith("--screen-capture-dir="))
+			{
+				screenCaptureDir = arg.fromFirstOccurrenceOf("--screen-capture-dir=", false, false).toStdString();
+			}
 		}
 
-		mainWindow.reset(new MainWindow(getApplicationNameWithBuildInfo(), logFile.currentLogFile(), vtNumber));
+		mainWindow.reset(new MainWindow(getApplicationNameWithBuildInfo(), logFile.currentLogFile(), vtNumber, screenCaptureDir));
 	}
 
 	void shutdown() override
@@ -118,8 +124,9 @@ public:
      * @brief MainWindow
      * @param name - window name to be displayed in the window title
      * @param vtNumberCmdLineArg - in the range of 1 - 32
+     * @param screenCaptureDir - path to the directory where the screen capture results will be saved
      */
-		MainWindow(juce::String name, const std::string &canLogPath, int vtNumberCmdLineArg = 0);
+		MainWindow(juce::String name, const std::string &canLogPath, int vtNumberCmdLineArg = 0, std::string screenCaptureDir = "");
 
 		/* Note: Be careful if you override any DocumentWindow methods - the base
            class uses a lot of them, so by overriding you might break its functionality.

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -25,7 +25,8 @@ public:
 	                    std::vector<std::shared_ptr<isobus::CANHardwarePlugin>> &canDrivers,
 	                    std::shared_ptr<ValueTree> settings,
 	                    const std::string &canLogPath_,
-	                    std::uint8_t vtNumberArg = 0);
+	                    std::uint8_t vtNumberArg = 0,
+	                    std::string screenCaptureDir = "");
 	~ServerMainComponent() override;
 
 	bool get_is_enough_memory(std::uint32_t requestedMemory) const override;
@@ -122,6 +123,9 @@ public:
 
 	void identify_vt() override;
 
+	void screen_capture(std::uint8_t item, std::uint8_t path, std::shared_ptr<isobus::ControlFunction> requestor) override;
+
+	static std::string getAppDataDir();
 	/**
    * @brief minimum_height
    * @return the height of the softkey- or the datamask size, whichever is bigger
@@ -161,7 +165,7 @@ private:
 	struct HeldButtonData
 	{
 		HeldButtonData(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, std::uint16_t objectID, std::uint16_t maskObjectID, std::uint8_t keyCode, bool isSoftKey);
-		bool operator==(const HeldButtonData &other);
+		bool operator==(const HeldButtonData &other) const;
 		std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> associatedWorkingSet;
 		std::uint32_t timestamp_ms;
 		std::uint16_t buttonObjectID;
@@ -184,6 +188,7 @@ private:
 	void clear_iso_data();
 
 	const std::string ISO_DATA_PATH = "iso_data";
+	std::string screenCaptureDirArgument = "";
 	std::string canLogPath;
 
 	juce::ApplicationCommandManager mCommandManager;

--- a/src/ASCIILogFile.cpp
+++ b/src/ASCIILogFile.cpp
@@ -5,6 +5,8 @@
 *******************************************************************************/
 #include "ASCIILogFile.hpp"
 
+#include "ServerMainComponent.hpp"
+
 #include "isobus/utility/system_timing.hpp"
 #include "isobus/utility/to_string.hpp"
 
@@ -16,9 +18,7 @@ ASCIILogFile::ASCIILogFile()
 	fileNameTime = currentTime.replaceCharacter(' ', '_');
 	fileNameTime = currentTime.replaceCharacter(':', '_');
 
-	logFile = File(File::getSpecialLocation(File::userApplicationDataDirectory).getFullPathName() +
-	               File::getSeparatorString() +
-	               "Open-Agriculture" +
+	logFile = File(ServerMainComponent::getAppDataDir() +
 	               File::getSeparatorString() +
 	               "CANLog_" +
 	               fileNameTime +

--- a/src/LoggerComponent.cpp
+++ b/src/LoggerComponent.cpp
@@ -8,10 +8,12 @@
 //================================================================================================
 #include "LoggerComponent.hpp"
 
+#include "ServerMainComponent.hpp"
+
 #include "Main.hpp"
 
 LoggerComponent::LoggerComponent() :
-  FileLogger(File(File::getSpecialLocation(File::userApplicationDataDirectory).getFullPathName() + "/Open-Agriculture/AgISOVirtualTerminalLog.txt"),
+  FileLogger(File(ServerMainComponent::getAppDataDir() + "/AgISOVirtualTerminalLog.txt"),
              "Starting " + AgISOVirtualTerminalApplication::getApplicationNameWithBuildInfo(),
              1024000)
 {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -9,7 +9,10 @@
 #include "Settings.hpp"
 #include "git.h"
 
-AgISOVirtualTerminalApplication::MainWindow::MainWindow(juce::String name, const std::string &canLogPath, int vtNumberCmdLineArg) :
+AgISOVirtualTerminalApplication::MainWindow::MainWindow(juce::String name,
+                                                        const std::string &canLogPath,
+                                                        int vtNumberCmdLineArg,
+                                                        std::string screenCaptureDir) :
   DocumentWindow(name,
                  juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId),
                  DocumentWindow::allButtons)
@@ -76,7 +79,7 @@ AgISOVirtualTerminalApplication::MainWindow::MainWindow(juce::String name, const
 	serverNAME.set_manufacturer_code(1407);
 	serverInternalControlFunction = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(serverNAME, 0, 0x26);
 	setUsingNativeTitleBar(true);
-	setContentOwned(new ServerMainComponent(serverInternalControlFunction, canDrivers, settings.settingsValueTree(), canLogPath, vtNumber), true);
+	setContentOwned(new ServerMainComponent(serverInternalControlFunction, canDrivers, settings.settingsValueTree(), canLogPath, vtNumber, screenCaptureDir), true);
 
 #if JUCE_IOS || JUCE_ANDROID
 	setFullScreen(true);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -5,6 +5,8 @@
 *******************************************************************************/
 #include "Settings.hpp"
 
+#include "ServerMainComponent.hpp"
+
 Settings::Settings()
 {
 	m_settings = std::make_shared<ValueTree>("Settings");
@@ -16,9 +18,7 @@ Settings::~Settings()
 
 bool Settings::load_settings()
 {
-	auto lDefaultSaveLocation = File::getSpecialLocation(File::userApplicationDataDirectory);
-	String lDataDirectoryPath = (lDefaultSaveLocation.getFullPathName().toStdString() + "/Open-Agriculture");
-	File dataDirectory(lDataDirectoryPath);
+	File dataDirectory(ServerMainComponent::getAppDataDir());
 	bool lCanLoadSettings = false;
 
 	if (dataDirectory.exists() && dataDirectory.isDirectory())
@@ -32,7 +32,7 @@ bool Settings::load_settings()
 
 	if (lCanLoadSettings)
 	{
-		String lFilePath = (lDefaultSaveLocation.getFullPathName().toStdString() + "/Open-Agriculture/" + "vt_settings.xml");
+		String lFilePath = (ServerMainComponent::getAppDataDir() + File::getSeparatorString() + "vt_settings.xml");
 		File settingsFile = File(lFilePath);
 
 		if (settingsFile.existsAsFile())


### PR DESCRIPTION
Added capability to make screen captures with the Screen capture command.
By default the screenshots are shared to the local settings directory/screen captures folder.
Command line option is also added to customize the folder path. (For automated testing for e.g.)