### PR TITLE
Fix rendering objects behind multiple object pointers

### DIFF
--- a/include/ObjectPointerComponent.hpp
+++ b/include/ObjectPointerComponent.hpp
@@ -27,6 +27,7 @@ public:
 private:
 	std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> parentWorkingSet;
 	std::shared_ptr<Component> childComponent;
+	void getChildSizeRecursive(int &w, int &h) const;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ObjectPointerComponent)
 };

--- a/src/ObjectPointerComponent.cpp
+++ b/src/ObjectPointerComponent.cpp
@@ -24,9 +24,11 @@ void ObjectPointerComponent::on_content_changed(bool initial)
 
 		if (nullptr != childComponent)
 		{
+			int w = 0, h = 0;
 			addAndMakeVisible(*childComponent);
 			childComponent->setTopLeftPosition(get_child_x(0), get_child_y(0));
-			setSize(child->get_width(), child->get_height());
+			std::static_pointer_cast<ObjectPointerComponent>(childComponent)->getChildSizeRecursive(w, h);
+			setSize(w, h);
 		}
 	}
 
@@ -36,6 +38,27 @@ void ObjectPointerComponent::on_content_changed(bool initial)
 	}
 }
 
-void ObjectPointerComponent::paint(Graphics &)
+void ObjectPointerComponent::paint(Graphics &g)
 {
+}
+
+void ObjectPointerComponent::getChildSizeRecursive(int &w, int &h) const
+{
+	auto child = get_object_by_id(get_value(), parentWorkingSet->get_object_tree());
+	if (nullptr != child)
+	{
+		if (child->get_object_type() == isobus::VirtualTerminalObjectType::ObjectPointer)
+		{
+			int numChildren = getNumChildComponents();
+			if (numChildren == 1)
+			{
+				static_cast<ObjectPointerComponent *>(getChildComponent(0))->getChildSizeRecursive(w, h);
+			}
+		}
+		else
+		{
+			w = child->get_width();
+			h = child->get_height();
+		}
+	}
 }


### PR DESCRIPTION
Components behind more than one object pointer (OP) was not visible because the size of the OPs higher than the last OP in the tree was not calculated properly.

The OPs does not have size defined by themselves, they do determine their size by their child sizes. However if an OP's children is an also OP the size of the parent OP was set to 0, 0.

A recursive funciton was added to the ObjectPointerComponent to travel down to the first child which is not an OP and determine the size based on that child.

Fixes martonmiklos/AgIsoVirtualTerminal#26