### PR TITLE
Fetch tags before CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
+          fetch-depth: 0
       - name: Compile
         run: |
           mkdir build
@@ -36,6 +37,7 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
+          fetch-depth: 0
       - name: Compile
         run: |
           mkdir build
@@ -55,6 +57,7 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
+          fetch-depth: 0
       - name: Compile
         run: |
           mkdir build
@@ -78,6 +81,7 @@ jobs:
         with:
           submodules: recursive
           fetch-tags: true
+          fetch-depth: 0
       - name: Compile
         run: |
           mkdir build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-tags: true
       - name: Compile
         run: |
           mkdir build
@@ -34,6 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-tags: true
       - name: Compile
         run: |
           mkdir build
@@ -52,6 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-tags: true
       - name: Compile
         run: |
           mkdir build
@@ -74,6 +77,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-tags: true
       - name: Compile
         run: |
           mkdir build


### PR DESCRIPTION
Without this the version number was not generated by the cmake-git-versioning properly