### PR TITLE
Use double arithmetic in Input/OutputNumber value calculation

### DIFF
--- a/src/InputNumberComponent.cpp
+++ b/src/InputNumberComponent.cpp
@@ -32,7 +32,7 @@ void InputNumberComponent::paint(Graphics &g)
 		g.fillAll(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0f));
 	}
 
-	float scaledValue = (get_value() + get_offset()) * get_scale();
+	double scaledValue = (static_cast<double>(get_value()) + static_cast<double>(get_offset())) * static_cast<double>(get_scale());
 	g.setColour(getLookAndFeel().findColour(ListBox::textColourId));
 
 	// Get font data
@@ -60,7 +60,8 @@ void InputNumberComponent::paint(Graphics &g)
 		if ((nullptr != child) &&
 		    (isobus::VirtualTerminalObjectType::NumberVariable == child->get_object_type()))
 		{
-			scaledValue = (std::static_pointer_cast<isobus::NumberVariable>(child)->get_value() + get_offset()) * get_scale();
+			double val = static_cast<double>(std::static_pointer_cast<isobus::NumberVariable>(child)->get_value());
+			scaledValue = (val + static_cast<double>(get_offset())) * static_cast<double>(get_scale());
 		}
 	}
 

--- a/src/OutputNumberComponent.cpp
+++ b/src/OutputNumberComponent.cpp
@@ -32,7 +32,7 @@ void OutputNumberComponent::paint(Graphics &g)
 		g.fillAll(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0f));
 	}
 
-	float scaledValue = (get_value() + get_offset()) * get_scale();
+	double scaledValue = (static_cast<double>(get_value()) + static_cast<double>(get_offset())) * static_cast<double>(get_scale());
 	g.setColour(getLookAndFeel().findColour(ListBox::textColourId));
 
 	// Get font data
@@ -60,7 +60,7 @@ void OutputNumberComponent::paint(Graphics &g)
 		if ((nullptr != child) && (isobus::VirtualTerminalObjectType::NumberVariable == child->get_object_type()))
 		{
 			std::int64_t offsetValue = static_cast<std::int64_t>(std::static_pointer_cast<isobus::NumberVariable>(child)->get_value()) + get_offset();
-			scaledValue = offsetValue * get_scale();
+			scaledValue = static_cast<double>(offsetValue) * static_cast<double>(get_scale());
 		}
 	}
 


### PR DESCRIPTION
The standard says:
<img width="1078" height="55" alt="kép" src="https://github.com/user-attachments/assets/5455b384-5cb1-4732-a277-88e9b67cae81" />

The NX9 test implement has a test input where we displayed a quite off value:
<img width="460" height="425" alt="kép" src="https://github.com/user-attachments/assets/723cdd98-97c1-470b-8934-6503210db9ed" />
(-50000000 offset 0 value, 1.0e-7 scale).

