### PR TITLE
Extended gitignore:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,13 @@ out
 build
 
 # QtCreator cmake temp files
-CMakeLists.txt.user
+CMakeLists.txt.user*
 
 # KDE hidden file artifacts
 .directory
 
 # QtCreator creates this folder
 CMakeFiles
+
+*.orig
+*.rej


### PR DESCRIPTION
- ignore all temporary CMakeLists files generated by QtCreator
- ignore *.rej, *.orig files generated by git