### PR TITLE
Add option to save diagnostic package from the current session only

### DIFF
--- a/include/ASCIILogFile.hpp
+++ b/include/ASCIILogFile.hpp
@@ -21,6 +21,8 @@ public:
 
 	~ASCIILogFile() = default;
 
+	std::string currentLogFile() const;
+
 private:
 	File logFile;
 	isobus::EventCallbackHandle canFrameReceivedListener;

--- a/include/LoggerComponent.hpp
+++ b/include/LoggerComponent.hpp
@@ -28,6 +28,8 @@ public:
 	void sink_CAN_stack_log(LoggingLevel level, const std::string &logText) override;
 	static constexpr int HEIGHT = 200;
 
+	std::uint64_t initialPos() const;
+
 private:
 	struct LogData
 	{
@@ -36,6 +38,8 @@ private:
 	};
 	static constexpr std::size_t MAX_NUMBER_MESSAGES = 3000;
 	std::deque<LogData> loggedMessages;
+
+	std::uint64_t startPos = 0;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LoggerComponent)
 };

--- a/include/Main.hpp
+++ b/include/Main.hpp
@@ -60,7 +60,7 @@ public:
 			}
 		}
 
-		mainWindow.reset(new MainWindow(getApplicationNameWithBuildInfo(), vtNumber));
+		mainWindow.reset(new MainWindow(getApplicationNameWithBuildInfo(), logFile.currentLogFile(), vtNumber));
 	}
 
 	void shutdown() override
@@ -119,7 +119,7 @@ public:
      * @param name - window name to be displayed in the window title
      * @param vtNumberCmdLineArg - in the range of 1 - 32
      */
-		MainWindow(juce::String name, int vtNumberCmdLineArg = 0);
+		MainWindow(juce::String name, const std::string &canLogPath, int vtNumberCmdLineArg = 0);
 
 		/* Note: Be careful if you override any DocumentWindow methods - the base
            class uses a lot of them, so by overriding you might break its functionality.

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -24,6 +24,7 @@ public:
 	ServerMainComponent(std::shared_ptr<isobus::InternalControlFunction> serverControlFunction,
 	                    std::vector<std::shared_ptr<isobus::CANHardwarePlugin>> &canDrivers,
 	                    std::shared_ptr<ValueTree> settings,
+	                    const std::string &canLogPath_,
 	                    std::uint8_t vtNumberArg = 0);
 	~ServerMainComponent() override;
 
@@ -138,6 +139,7 @@ private:
 		ConfigureLogging,
 		ConfigureShortcuts,
 		GenerateLogPackage,
+		GenerateLogPackageFromCurrentSession,
 		ClearISOData,
 		ConfigureCANHardware,
 		StartStop,
@@ -182,6 +184,7 @@ private:
 	void clear_iso_data();
 
 	const std::string ISO_DATA_PATH = "iso_data";
+	std::string canLogPath;
 
 	juce::ApplicationCommandManager mCommandManager;
 	WorkingSetSelectorComponent workingSetSelector;
@@ -200,6 +203,7 @@ private:
 	std::shared_ptr<isobus::ControlFunction> alarmAckKeyWs;
 	std::vector<std::shared_ptr<isobus::CANHardwarePlugin>> &parentCANDrivers;
 	std::vector<HeldButtonData> heldButtons;
+	std::set<std::string> loadedNames;
 	std::uint32_t alarmAckKeyMaskId = isobus::NULL_OBJECT_ID;
 	int alarmAckKeyCode = juce::KeyPress::escapeKey;
 	std::uint8_t vtNumber = 1; // VT number in the range of 1-32

--- a/src/ASCIILogFile.cpp
+++ b/src/ASCIILogFile.cpp
@@ -109,3 +109,8 @@ ASCIILogFile::ASCIILogFile()
 		RuntimePermissions::request(RuntimePermissions::writeExternalStorage, nullptr);
 	}
 }
+
+std::string ASCIILogFile::currentLogFile() const
+{
+	return logFile.getFullPathName().toStdString();
+}

--- a/src/LoggerComponent.cpp
+++ b/src/LoggerComponent.cpp
@@ -17,6 +17,8 @@ LoggerComponent::LoggerComponent() :
 {
 	auto bounds = getLocalBounds();
 	setBounds(10, 10, bounds.getWidth() - 10, bounds.getHeight() - 10);
+
+	startPos = getLogFile().getSize();
 }
 
 void LoggerComponent::paint(Graphics &g)
@@ -88,4 +90,9 @@ void LoggerComponent::sink_CAN_stack_log(LoggingLevel level, const std::string &
 	setSize(bounds.getWidth(), newSize);
 	repaint();
 	logMessage(logText);
+}
+
+std::uint64_t LoggerComponent::initialPos() const
+{
+	return startPos;
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -9,7 +9,7 @@
 #include "Settings.hpp"
 #include "git.h"
 
-AgISOVirtualTerminalApplication::MainWindow::MainWindow(juce::String name, int vtNumberCmdLineArg) :
+AgISOVirtualTerminalApplication::MainWindow::MainWindow(juce::String name, const std::string &canLogPath, int vtNumberCmdLineArg) :
   DocumentWindow(name,
                  juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId),
                  DocumentWindow::allButtons)
@@ -76,7 +76,7 @@ AgISOVirtualTerminalApplication::MainWindow::MainWindow(juce::String name, int v
 	serverNAME.set_manufacturer_code(1407);
 	serverInternalControlFunction = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(serverNAME, 0, 0x26);
 	setUsingNativeTitleBar(true);
-	setContentOwned(new ServerMainComponent(serverInternalControlFunction, canDrivers, settings.settingsValueTree(), vtNumber), true);
+	setContentOwned(new ServerMainComponent(serverInternalControlFunction, canDrivers, settings.settingsValueTree(), canLogPath, vtNumber), true);
 
 #if JUCE_IOS || JUCE_ANDROID
 	setFullScreen(true);


### PR DESCRIPTION
Many times it takes some time to drop old irrelevant data from the diagnostic packages.
Creating an option to save only the logs generated in the current session (including the IOPs loaded/used in the current session) could help to speed up diagnostic packages review.