### PR TITLE
Add option to save IOP before parse

### DIFF
--- a/cmake/FindCAN_Stack.cmake
+++ b/cmake/FindCAN_Stack.cmake
@@ -3,6 +3,6 @@ if(NOT TARGET isobus::isobus)
   FetchContent_Declare(
     CAN_Stack
     GIT_REPOSITORY https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git
-    GIT_TAG 2dd415cd54a148115ebdd2128bd6366d097d28a4)
+    GIT_TAG a192d1a5bdb7ac834dbe6a45af19d15fd735572e)
   FetchContent_MakeAvailable(CAN_Stack)
 endif()

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -173,6 +173,7 @@ private:
 	std::size_t number_of_iop_files_in_directory(std::filesystem::path path);
 
 	bool timeAndDateCallback(isobus::TimeDateInterface::TimeAndDate &timeAndDateToPopulate);
+	void transferred_object_pool_parse_start(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> &workingSet) const override;
 
 	void on_change_active_mask_callback(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> affectedWorkingSet, std::uint16_t workingSet, std::uint16_t newMask);
 	void repaint_data_and_soft_key_mask();
@@ -208,6 +209,7 @@ private:
 	bool autostart = false;
 	bool hasStartBeenCalled = false;
 	bool alarmAckKeyPressed = false;
+	bool saveIopBeforeParse = false;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ServerMainComponent)
 };


### PR DESCRIPTION
In the case if the VT app crashes during IOP parsing there will be no stored IOP to perform debugging. This PR add an option to the Logging settings: "Save IOP data before parsing". If this option is checked the IOP will be saved to the settings folder/debug.iop which can shared and debugged with the iop_parser_tester in the stack independently from the implement.