### PR TITLE
Fix displaying UTF16 encoded strings

### DIFF
--- a/src/OutputStringComponent.cpp
+++ b/src/OutputStringComponent.cpp
@@ -18,12 +18,25 @@ OutputStringComponent::OutputStringComponent(std::shared_ptr<isobus::VirtualTerm
 void OutputStringComponent::paint(Graphics &g)
 {
 	std::string value = displayed_value(parentWorkingSet);
-
-	std::size_t pos = value.find('\0');
-	if (pos != std::string::npos)
+	std::size_t pos = 0;
+	if ((value.length() >= 2) && (0xFF == static_cast<std::uint8_t>(value.at(0))) && (0xFE == static_cast<std::uint8_t>(value.at(1))))
 	{
-		value = value.substr(0, pos);
+		// UTF16 string
+		for (std::size_t i = 2; i + 1 < value.size(); i += 2)
+		{
+			if (value[i] == 0 && value[i + 1] == 0)
+			{
+				pos = i;
+				break;
+			}
+		}
 	}
+	else
+	{
+		// non UTF16 string
+		pos = value.find('\0');
+	}
+	value = value.substr(0, pos);
 
 	std::uint8_t fontHeight = 0;
 	auto fontType = isobus::FontAttributes::FontType::ISO8859_1;


### PR DESCRIPTION
I came across a Kverneland implement which does not displayed a string:

AgIsoVT:

<img width="787" height="542" alt="Image" src="https://github.com/user-attachments/assets/8f148def-d8ef-42ab-a39a-64d38c05f406" />

NX9:

<img width="1106" height="658" alt="Image" src="https://github.com/user-attachments/assets/b09603da-f9a3-4ee7-bbaf-9cc3ab067347" />



The source turned out to be the mishandling of the UT16 strings in the OutputString rendering: the strings were cut at the first occurrence of the \0 character, however with UTF16 strings the \0 characters could occur in the UTF16 pairs.

