### PR TITLE
Add missing std:: prefixes

### DIFF
--- a/src/ButtonComponent.cpp
+++ b/src/ButtonComponent.cpp
@@ -58,12 +58,12 @@ void ButtonComponent::paintButton(Graphics &, bool, bool)
 {
 }
 
-void ButtonComponent::set_options(uint8_t value)
+void ButtonComponent::set_options(std::uint8_t value)
 {
 	// adjust the position of the childs to the button face area if the NoBorder attribute is changed
-	if ((value & static_cast<uint8_t>(Options::NoBorder)) != get_option(Options::NoBorder))
+	if ((value & static_cast<std::uint8_t>(Options::NoBorder)) != get_option(Options::NoBorder))
 	{
-		auto borderOffset = (0 != (value & static_cast<uint8_t>(Options::NoBorder))) ? -4 : 4;
+		auto borderOffset = (0 != (value & static_cast<std::uint8_t>(Options::NoBorder))) ? -4 : 4;
 		int i = 0;
 		for (auto &child : childComponents)
 		{

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -31,7 +31,7 @@ ServerMainComponent::ServerMainComponent(
   std::vector<std::shared_ptr<isobus::CANHardwarePlugin>> &canDrivers,
   std::shared_ptr<ValueTree> settings,
   const std::string &canLogPath_,
-  uint8_t vtNumberArg,
+  std::uint8_t vtNumberArg,
   std::string screenCaptureDir) :
   VirtualTerminalServer(serverControlFunction), screenCaptureDirArgument(screenCaptureDir), workingSetSelector(*this), dataMaskRenderer(*this), softKeyMaskRenderer(*this), parentCANDrivers(canDrivers), canLogPath(canLogPath_)
 {
@@ -186,12 +186,12 @@ std::uint8_t ServerMainComponent::get_number_of_physical_soft_keys() const
 	}
 }
 
-uint8_t ServerMainComponent::get_physical_soft_key_columns() const
+std::uint8_t ServerMainComponent::get_physical_soft_key_columns() const
 {
 	return softKeyMaskDimensions.columnCount < 1 ? 1 : softKeyMaskDimensions.columnCount;
 }
 
-uint8_t ServerMainComponent::get_physical_soft_key_rows() const
+std::uint8_t ServerMainComponent::get_physical_soft_key_rows() const
 {
 	return softKeyMaskDimensions.rowCount < 1 ? 1 : softKeyMaskDimensions.rowCount;
 }

--- a/src/StringEncodingConversions.cpp
+++ b/src/StringEncodingConversions.cpp
@@ -136,9 +136,9 @@ constexpr std::uint16_t iso_8859_7_utf8[256] =
 
 // clang-format on
 
-static const uint16_t *getTable(SourceEncoding encoding)
+static const std::uint16_t *getTable(SourceEncoding encoding)
 {
-	const uint16_t *retVal = nullptr;
+	const std::uint16_t *retVal = nullptr;
 
 	switch (encoding)
 	{
@@ -181,7 +181,7 @@ static const uint16_t *getTable(SourceEncoding encoding)
 	return retVal;
 }
 
-static void add_character(uint16_t character, std::string &output)
+static void add_character(std::uint16_t character, std::string &output)
 {
 	if (character < 0x80)
 	{
@@ -208,7 +208,7 @@ void convert_string_to_utf_8(SourceEncoding encoding, const std::string &input, 
 
 	for (const unsigned char encodedChar : input)
 	{
-		uint16_t newCharacter = table[encodedChar];
+		std::uint16_t newCharacter = table[encodedChar];
 
 		if (((static_cast<std::uint8_t>(encodedChar) >= 0x7F) &&
 		     (static_cast<std::uint8_t>(encodedChar) <= 0xA0)) ||


### PR DESCRIPTION
Title says all: clang-tidy plugin reported some missing std:: prefixes, so I fixed them.