### PR TITLE
Use font color from font attributes (regression fix after #73)

### DIFF
--- a/src/NumberComponent.cpp
+++ b/src/NumberComponent.cpp
@@ -39,6 +39,8 @@ void NumberComponent::paintNumber(Graphics &g, bool enabled)
 			{
 				return;
 			}
+			auto colour = parentWorkingSet->get_colour(font->get_colour());
+			drawColour = Colour::fromFloatRGBA(colour.r, colour.g, colour.b, 1.0f);
 			strikeThrough = font->get_style(isobus::FontAttributes::FontStyleBits::CrossedOut);
 			prepare_text_painting(g, font, '1', drawColour, backgroundColour);
 		}

--- a/src/StringDrawingComponent.cpp
+++ b/src/StringDrawingComponent.cpp
@@ -49,6 +49,8 @@ void StringDrawingComponent::paintString(Graphics &g, const std::string &text, b
 			}
 			fontHeight = prepare_text_painting(g, font, 'a', drawColour, backgroundColour);
 			strikeThrough = font->get_style(isobus::FontAttributes::FontStyleBits::CrossedOut);
+			auto colour = parentWorkingSet->get_colour(font->get_colour());
+			drawColour = Colour::fromFloatRGBA(colour.r, colour.g, colour.b, 1.0f);
 			fontType = font->get_type();
 		}
 	}


### PR DESCRIPTION
Drawing with custom font color specified in font attributes got broken in #73