### PR TITLE
Call setApplicationCommandManagerToWatch with nullptr in the

### DIFF
--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -103,6 +103,7 @@ ServerMainComponent::ServerMainComponent(
 
 ServerMainComponent::~ServerMainComponent()
 {
+	setApplicationCommandManagerToWatch(nullptr);
 }
 
 bool ServerMainComponent::get_is_enough_memory(std::uint32_t) const


### PR DESCRIPTION
ServerMainComponent destructor

AddressSanitizer reported heap-use-after-free without this:

```
==113616==ERROR: AddressSanitizer: heap-use-after-free on address 0x50300012dc70 at pc 0x5fcb6b67ee31 bp 0x7ffd5e061a60 sp 0x7ffd5e061a50
READ of size 8 at 0x50300012dc70 thread T0
 #0 0x5fcb6b67ee30 in juce::HeapBlock<juce::ApplicationCommandManagerListener*, false>::operator juce::ApplicationCommandManagerListener**() const (/home/mm/Projektek/digitroll/AgIsoVirtualTerminal/build/Desktop-Debug/AgISOVirtualTerminal_artefacts/Debug/AgISOVirtualTerminal+0xa1de30) (BuildId: 2dcae6ed527835d595f7c726b1ea4cd4b33bd3e6)
 #1 0x5fcb6b5f90e9 in juce::ArrayBase<juce::ApplicationCommandManagerListener*, juce::DummyCriticalSection>::begin() /home/mm/Projektek/digitroll/AgIsoVirtualTerminal/build/Desktop-Debug/_deps/juce-src/modules/juce_core/containers/juce_ArrayBase.h:186
 #2 0x5fcb6b56200a in juce::Array<juce::ApplicationCommandManagerListener*, juce::DummyCriticalSection, 0>::removeFirstMatchingValue(juce::ApplicationCommandManagerListener*) (/home/mm/Projektek/digitroll/AgIsoVirtualTerminal/build/Desktop-Debug/AgISOVirtualTerminal_artefacts/Debug/AgISOVirtualTerminal+0x90100a) (BuildId: 2dcae6ed527835d595f7c726b1ea4cd4b33bd3e6)
 #3 0x5fcb6b4af93b in juce::ListenerList<juce::ApplicationCommandManagerListener, juce::Array<juce::ApplicationCommandManagerListener*, juce::DummyCriticalSection, 0> >::remove(juce::ApplicationCommandManagerListener*) /home/mm/Projektek/digitroll/AgIsoVirtualTerminal/build/Desktop-Debug/_deps/juce-src/modules/juce_core/containers/juce_ListenerList.h:116
 #4 0x5fcb6b1afb68 in juce::ApplicationCommandManager::removeListener(juce::ApplicationCommandManagerListener*) /home/mm/Projektek/digitroll/AgIsoVirtualTerminal/build/Desktop-Debug/_deps/juce-src/modules/juce_gui_basics/commands/juce_ApplicationCommandManager.cpp:313
 #5 0x5fcb6b296cea in juce::MenuBarModel::setApplicationCommandManagerToWatch(juce::ApplicationCommandManager*) /home/mm/Projektek/digitroll/AgIsoVirtualTerminal/build/Desktop-Debug/_deps/juce-src/modules/juce_gui_basics/menus/juce_MenuBarModel.cpp:59
 #6 0x5fcb6b296bd1 in juce::MenuBarModel::~MenuBarModel() /home/mm/Projektek/digitroll/AgIsoVirtualTerminal/build/Desktop-Debug/_deps/juce-src/modules/juce_gui_basics/menus/juce_MenuBarModel.cpp:45
 #7 0x5fcb6af36ef4 in ServerMainComponent::~ServerMainComponent() /home/mm/Projektek/digitroll/AgIsoVirtualTerminal/src/ServerMainComponent.cpp:107
 #8 0x5fcb6af36fb7 in ServerMainComponent::~ServerMainComponent() /home/mm/Projektek/digitroll/AgIsoVirtualTerminal/src/ServerMainComponent.cpp:107
 #9 0x5fcb6b4bfb93 in juce::Component::SafePointer<juce::Component>::deleteAndZero() (/home/mm/Projektek/digitroll/AgIsoVirtualTerminal/build/Desktop-Debug/AgISOVirtualTerminal_artefacts/Debug/AgISOVirtualTerminal+0x85eb93) (BuildId: 2dcae6ed527835d595f7c726b1ea4cd4b33bd3e6)
```

When compiled with:

```
target_compile_options(AgISOVirtualTerminal PRIVATE
    -fsanitize=address
    -fno-omit-frame-pointer
    -g
    -O0
)

target_link_options(AgISOVirtualTerminal PRIVATE
    -fsanitize=address
)
```

And ran with:
```
export ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:handle_segv=1:print_stats=1"
export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"
```
