### PR TITLE
Draw button border above the button's childs

### DIFF
--- a/include/ButtonComponent.hpp
+++ b/include/ButtonComponent.hpp
@@ -22,6 +22,8 @@ public:
 
 	void paint(Graphics &g) override;
 
+	void paintOverChildren(Graphics &g) override;
+
 	void paintButton(Graphics &g, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) override;
 
 	void set_options(std::uint8_t value) override;

--- a/src/ButtonComponent.cpp
+++ b/src/ButtonComponent.cpp
@@ -45,10 +45,13 @@ void ButtonComponent::paint(Graphics &g)
 	{
 		g.fillAll(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0f));
 	}
+}
 
+void ButtonComponent::paintOverChildren(Graphics &g)
+{
 	if (false == get_option(Options::NoBorder) && false == get_option(Options::SuppressBorder))
 	{
-		vtColour = parentWorkingSet->get_colour(get_border_colour());
+		auto vtColour = parentWorkingSet->get_colour(get_border_colour());
 		g.setColour(Colour::fromFloatRGBA(vtColour.r, vtColour.g, vtColour.b, 1.0f));
 		g.drawRect(0, 0, get_width(), get_height(), 4);
 	}


### PR DESCRIPTION
Buttons with child objects over drawn the border before:
<img width="144" height="95" alt="kép" src="https://github.com/user-attachments/assets/a92788e0-0abc-4fa6-8d55-e02bb7f7cd32" />

With this fix it no longer happen:
<img width="259" height="115" alt="kép" src="https://github.com/user-attachments/assets/f99d319e-ee16-4fed-82c4-8cca5a4602e3" />
