### PR TITLE
Add option for dedicated ACK button

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ target_sources(
           "src/ConfigureHardwareComponent.cpp"
           "src/StringEncodingConversions.cpp"
           "src/InputListComponent.cpp"
-          "src/ShortcutsWindow.cpp"
+          "src/AckSettingsWindow.cpp"
           "src/Settings.cpp"
           "src/VT_NumberComponent.cpp"
           "src/TextDrawingComponent.cpp"

--- a/include/AckSettingsWindow.hpp
+++ b/include/AckSettingsWindow.hpp
@@ -1,7 +1,7 @@
 //================================================================================================
-/// @file ShortcutsWindow.hpp
+/// @file AckSettingsWindow.hpp
 ///
-/// @brief Defines a dialog where keyboard shortcuts could be selected
+/// @brief Defines a dialog where ACK settings can be configured
 /// @author Miklos Marton
 ///
 /// @copyright The Open-Agriculture Developers
@@ -10,18 +10,20 @@
 
 #include "JuceHeader.h"
 
-class ShortcutsWindow : public juce::AlertWindow
+class AckSettingsWindow : public juce::AlertWindow
   , public juce::KeyListener
 {
 public:
-	ShortcutsWindow(int alarmAckKeyCode, Component *associatedComponent = nullptr);
+	AckSettingsWindow(int alarmAckKeyCode, bool showAckButton, Component *associatedComponent = nullptr);
 
 	void resized() override;
 	bool keyPressed(const juce::KeyPress &key, juce::Component *originatingComponent) override;
 	int alarmAckKeyCode() const;
+	bool shouldShowAckButton() const;
 
 private:
 	juce::TextButton selectAlarmAckKeyButton;
+	juce::ToggleButton showAckButtonCheckbox;
 	int alarmAckKey = juce::KeyPress::escapeKey;
 
 	bool keySelectionMode = false;
@@ -30,5 +32,5 @@ private:
 
 	void setAlarmAckKeySelection(bool isEnabled);
 
-	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ShortcutsWindow)
+	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AckSettingsWindow)
 };

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -188,6 +188,8 @@ private:
 
 	void on_change_active_mask_callback(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> affectedWorkingSet, std::uint16_t workingSet, std::uint16_t newMask);
 	void repaint_data_and_soft_key_mask();
+	bool is_active_alarm_mask() const;
+	void update_ack_button_visibility();
 	void check_load_settings(std::shared_ptr<ValueTree> settings);
 	void remove_working_set(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSetToRemove);
 	void clear_iso_data();

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -117,6 +117,8 @@ public:
 
 	void change_selected_working_set(std::uint8_t index);
 
+	void send_alarm_ack_command(isobus::VirtualTerminalBase::KeyActivationCode activationCode);
+
 	void set_button_held(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, std::uint16_t objectID, std::uint16_t maskObjectID, std::uint8_t keyCode, bool isSoftKey);
 	void set_button_released(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, std::uint16_t objectID, std::uint16_t maskObjectID, std::uint8_t keyCode, bool isSoftKey);
 
@@ -221,6 +223,7 @@ private:
 	bool autostart = false;
 	bool hasStartBeenCalled = false;
 	bool alarmAckKeyPressed = false;
+	bool showAckButton = false;
 	bool saveIopBeforeParse = false;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ServerMainComponent)

--- a/include/WorkingSetSelectorComponent.hpp
+++ b/include/WorkingSetSelectorComponent.hpp
@@ -31,6 +31,7 @@ public:
 
 	void redraw();
 	void update_iop_load_indicators();
+	void set_ack_button_visible(bool shouldBeVisible);
 
 	static constexpr int WIDTH = 96;
 	static constexpr int BUTTON_WIDTH = 72;
@@ -38,6 +39,17 @@ public:
 	static constexpr int button_padding();
 
 private:
+	class AckButton : public juce::TextButton
+	{
+	public:
+		AckButton();
+
+		void paintButton(juce::Graphics &g, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) override;
+
+	private:
+		static constexpr float LABEL_WIDTH_RATIO = 0.8f;
+	};
+
 	struct SELECTOR_CHILD_OBJECTS_STRUCT
 	{
 		std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet;
@@ -45,10 +57,13 @@ private:
 	};
 	std::vector<SELECTOR_CHILD_OBJECTS_STRUCT> children;
 	ServerMainComponent &parentServer;
+	AckButton ackButton;
+	bool ackButtonPressed = false;
 
 	std::shared_ptr<Component> getWorkingSetChildComponent(
 	  std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet,
 	  int workingSetIndex);
+	void update_ack_button_bounds();
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WorkingSetSelectorComponent)
 };

--- a/src/AckSettingsWindow.cpp
+++ b/src/AckSettingsWindow.cpp
@@ -1,12 +1,12 @@
 /*******************************************************************************
-** @file       ShortcutsWindow.cpp
+** @file       AckSettingsWindow.cpp
 ** @author     Miklos Marton
 ** @copyright  The Open-Agriculture Developers
 *******************************************************************************/
-#include "ShortcutsWindow.hpp"
+#include "AckSettingsWindow.hpp"
 
-ShortcutsWindow::ShortcutsWindow(int alarmAckKeyCode, Component *associatedComponent) :
-  juce::AlertWindow("Keyboard shortcuts", "", MessageBoxIconType::NoIcon, associatedComponent),
+AckSettingsWindow::AckSettingsWindow(int alarmAckKeyCode, bool showAckButton, Component *associatedComponent) :
+  juce::AlertWindow("ACK button", "", MessageBoxIconType::NoIcon, associatedComponent),
   alarmAckKey(alarmAckKeyCode)
 {
 	juce::KeyPress alarmAckKey(alarmAckKeyCode);
@@ -14,20 +14,25 @@ ShortcutsWindow::ShortcutsWindow(int alarmAckKeyCode, Component *associatedCompo
 	selectAlarmAckKeyButton.onClick = [this]() { setAlarmAckKeySelection(true); };
 	updateAlarmAckButtonLabel(alarmAckKey);
 
+	showAckButtonCheckbox.setButtonText("Show ACK button");
+	showAckButtonCheckbox.setToggleState(showAckButton, juce::dontSendNotification);
+	addCustomComponent(&showAckButtonCheckbox);
+
 	addButton("OK", 5, KeyPress(KeyPress::returnKey, 0, 0));
 	addButton("Cancel", 0);
 
 	setAlarmAckKeySelection(false);
 }
 
-void ShortcutsWindow::resized()
+void AckSettingsWindow::resized()
 {
 	auto area = getLocalBounds();
 	auto customArea = area.removeFromTop(40).removeFromLeft(area.getWidth() / 1.2);
 	selectAlarmAckKeyButton.setBounds(customArea);
+	showAckButtonCheckbox.setBounds(customArea.translated(0, 40));
 }
 
-bool ShortcutsWindow::keyPressed(const KeyPress &key, Component *originatingComponent)
+bool AckSettingsWindow::keyPressed(const KeyPress &key, Component *originatingComponent)
 {
 	if (keySelectionMode)
 	{
@@ -39,17 +44,22 @@ bool ShortcutsWindow::keyPressed(const KeyPress &key, Component *originatingComp
 	return false;
 }
 
-int ShortcutsWindow::alarmAckKeyCode() const
+int AckSettingsWindow::alarmAckKeyCode() const
 {
 	return alarmAckKey;
 }
 
-void ShortcutsWindow::updateAlarmAckButtonLabel(const KeyPress &key)
+bool AckSettingsWindow::shouldShowAckButton() const
+{
+	return showAckButtonCheckbox.getToggleState();
+}
+
+void AckSettingsWindow::updateAlarmAckButtonLabel(const KeyPress &key)
 {
 	selectAlarmAckKeyButton.setButtonText("Alarm acknowledge key: " + key.getTextDescription());
 }
 
-void ShortcutsWindow::setAlarmAckKeySelection(bool isEnabled)
+void AckSettingsWindow::setAlarmAckKeySelection(bool isEnabled)
 {
 	keySelectionMode = isEnabled;
 	selectAlarmAckKeyButton.setEnabled(!isEnabled);

--- a/src/AckSettingsWindow.cpp
+++ b/src/AckSettingsWindow.cpp
@@ -14,7 +14,7 @@ AckSettingsWindow::AckSettingsWindow(int alarmAckKeyCode, bool showAckButton, Co
 	selectAlarmAckKeyButton.onClick = [this]() { setAlarmAckKeySelection(true); };
 	updateAlarmAckButtonLabel(alarmAckKey);
 
-	showAckButtonCheckbox.setButtonText("Show ACK button");
+	showAckButtonCheckbox.setButtonText("Show dedicated ACK button when an alarm mask is active");
 	showAckButtonCheckbox.setToggleState(showAckButton, juce::dontSendNotification);
 	addCustomComponent(&showAckButtonCheckbox);
 

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -5,10 +5,10 @@
 *******************************************************************************/
 #include "ServerMainComponent.hpp"
 
+#include "AckSettingsWindow.hpp"
 #include "AlarmMaskAudio.h"
 #include "JuceManagedWorkingSetCache.hpp"
 #include "Main.hpp"
-#include "ShortcutsWindow.hpp"
 #include "isobus/utility/system_timing.hpp"
 
 #include "SoftKeyMaskRenderAreaComponent.hpp"
@@ -224,17 +224,9 @@ bool ServerMainComponent::keyPressed(const KeyPress &key, Component *originating
 {
 	if (key == alarmAckKeyCode && !alarmAckKeyPressed)
 	{
-		for (auto &ws : managedWorkingSetList)
-		{
-			if (activeWorkingSetMasterAddress == ws->get_control_function()->get_address())
-			{
-				alarmAckKeyPressed = true;
-				alarmAckKeyMaskId = std::static_pointer_cast<isobus::WorkingSet>(ws->get_working_set_object())->get_active_mask();
-				alarmAckKeyWs = ws->get_control_function();
-				send_soft_key_activation_message(KeyActivationCode::ButtonPressedOrLatched, isobus::NULL_OBJECT_ID, alarmAckKeyMaskId, 0, alarmAckKeyWs);
-				return true;
-			}
-		}
+		alarmAckKeyPressed = true;
+		send_alarm_ack_command(KeyActivationCode::ButtonPressedOrLatched);
+		return true;
 	}
 	return false;
 }
@@ -244,9 +236,34 @@ bool ServerMainComponent::keyStateChanged(bool isKeyDown, Component *originating
 	if (!isKeyDown && alarmAckKeyPressed && !juce::KeyPress::isKeyCurrentlyDown(alarmAckKeyCode))
 	{
 		alarmAckKeyPressed = false;
-		send_soft_key_activation_message(KeyActivationCode::ButtonUnlatchedOrReleased, isobus::NULL_OBJECT_ID, alarmAckKeyMaskId, 0, alarmAckKeyWs);
+		send_alarm_ack_command(KeyActivationCode::ButtonUnlatchedOrReleased);
 	}
 	return false;
+}
+
+void ServerMainComponent::send_alarm_ack_command(KeyActivationCode activationCode)
+{
+	if (KeyActivationCode::ButtonUnlatchedOrReleased == activationCode)
+	{
+		if (nullptr != alarmAckKeyWs)
+		{
+			send_soft_key_activation_message(activationCode, isobus::NULL_OBJECT_ID, alarmAckKeyMaskId, 0, alarmAckKeyWs);
+			alarmAckKeyMaskId = isobus::NULL_OBJECT_ID;
+			alarmAckKeyWs.reset();
+		}
+		return;
+	}
+
+	for (auto &ws : managedWorkingSetList)
+	{
+		if (activeWorkingSetMasterAddress == ws->get_control_function()->get_address())
+		{
+			alarmAckKeyMaskId = std::static_pointer_cast<isobus::WorkingSet>(ws->get_working_set_object())->get_active_mask();
+			alarmAckKeyWs = ws->get_control_function();
+			send_soft_key_activation_message(activationCode, isobus::NULL_OBJECT_ID, alarmAckKeyMaskId, 0, alarmAckKeyWs);
+			return;
+		}
+	}
 }
 
 std::vector<std::array<std::uint8_t, 7>> ServerMainComponent::get_versions(isobus::NAME clientNAME)
@@ -784,7 +801,7 @@ void ServerMainComponent::getCommandInfo(juce::CommandID commandID, ApplicationC
 
 		case CommandIDs::ConfigureShortcuts:
 		{
-			result.setInfo("Configure shortcuts", "Configure keyboard shortcuts", "Configure", 0);
+			result.setInfo("ACK button", "Configure ACK keyboard shortcut and button", "Configure", 0);
 		}
 		break;
 
@@ -922,7 +939,7 @@ bool ServerMainComponent::perform(const InvocationInfo &info)
 
 		case static_cast<int>(CommandIDs::ConfigureShortcuts):
 		{
-			popupMenu = std::make_unique<ShortcutsWindow>(alarmAckKeyCode);
+			popupMenu = std::make_unique<AckSettingsWindow>(alarmAckKeyCode, showAckButton);
 			popupMenu->enterModalState(true, ModalCallbackFunction::create(LanguageCommandConfigClosed{ *this }));
 			retVal = true;
 		}
@@ -1388,11 +1405,15 @@ void ServerMainComponent::LanguageCommandConfigClosed::operator()(int result) co
 		}
 		break;
 
-		case 5: // Shortcuts
+		case 5: // ACK button
 		{
-			mParent.alarmAckKeyCode = dynamic_cast<ShortcutsWindow *>(mParent.popupMenu.get())->alarmAckKeyCode();
+			auto *ackSettingsWindow = dynamic_cast<AckSettingsWindow *>(mParent.popupMenu.get());
+			mParent.alarmAckKeyCode = ackSettingsWindow->alarmAckKeyCode();
+			mParent.showAckButton = ackSettingsWindow->shouldShowAckButton();
+			mParent.workingSetSelector.set_ack_button_visible(mParent.showAckButton);
 			mParent.save_settings();
 		}
+		break;
 
 		default:
 		{
@@ -1767,10 +1788,17 @@ void ServerMainComponent::check_load_settings(std::shared_ptr<ValueTree> setting
 			{
 				alarmAckKeyCode = static_cast<int>(child.getProperty("AlarmAckKey"));
 			}
+
+			if (!child.getProperty("ShowAckButton").isVoid())
+			{
+				showAckButton = static_cast<int>(child.getProperty("ShowAckButton")) != 0;
+			}
 		}
 		index++;
 		child = settings->getChild(index);
 	}
+
+	workingSetSelector.set_ack_button_visible(showAckButton);
 
 	if (!autostart)
 	{
@@ -1851,6 +1879,7 @@ void ServerMainComponent::save_settings()
 		loggingSettings.setProperty("SaveIopBeforeParse", static_cast<int>(saveIopBeforeParse), nullptr);
 		controlSettings.setProperty("AutoStart", autostart, nullptr);
 		controlSettings.setProperty("AlarmAckKey", alarmAckKeyCode, nullptr);
+		controlSettings.setProperty("ShowAckButton", showAckButton, nullptr);
 		settings.appendChild(languageCommandSettings, nullptr);
 		settings.appendChild(compatibilitySettings, nullptr);
 		settings.appendChild(hardwareSettings, nullptr);

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -631,6 +631,7 @@ void ServerMainComponent::timerCallback()
 			}
 			remove_working_set(ws);
 			workingSetSelector.update_drawn_working_sets(managedWorkingSetList);
+			update_ack_button_visibility();
 			break;
 		}
 		else if (isobus::VirtualTerminalServerManagedWorkingSet::ObjectPoolProcessingThreadState::Joined == ws->get_object_pool_processing_state())
@@ -1244,6 +1245,7 @@ void ServerMainComponent::change_selected_working_set(std::uint8_t index)
 		dataMaskRenderer.on_change_active_mask(ws);
 		softKeyMaskRenderer.on_change_active_mask(ws);
 		activeWorkingSet = ws;
+		update_ack_button_visibility();
 		process_macro(activeWorkingSet->get_working_set_object(), isobus::EventID::OnActivate, isobus::VirtualTerminalObjectType::WorkingSet, activeWorkingSet);
 		ws->save_callback_handle(get_on_repaint_event_dispatcher().add_listener([this](std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet>) { this->repaint_on_next_update(); }));
 		ws->save_callback_handle(get_on_change_active_mask_event_dispatcher().add_listener([this](std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> affectedWorkingSet, std::uint16_t workingSet, std::uint16_t newMask) { this->on_change_active_mask_callback(affectedWorkingSet, workingSet, newMask); }));
@@ -1410,7 +1412,7 @@ void ServerMainComponent::LanguageCommandConfigClosed::operator()(int result) co
 			auto *ackSettingsWindow = dynamic_cast<AckSettingsWindow *>(mParent.popupMenu.get());
 			mParent.alarmAckKeyCode = ackSettingsWindow->alarmAckKeyCode();
 			mParent.showAckButton = ackSettingsWindow->shouldShowAckButton();
-			mParent.workingSetSelector.set_ack_button_visible(mParent.showAckButton);
+			mParent.update_ack_button_visibility();
 			mParent.save_settings();
 		}
 		break;
@@ -1564,6 +1566,8 @@ void ServerMainComponent::on_change_active_mask_callback(std::shared_ptr<isobus:
 			}
 		}
 
+		update_ack_button_visibility();
+
 		if (nullptr != activeMask)
 		{
 			if (isobus::VirtualTerminalObjectType::AlarmMask == activeMask->get_object_type())
@@ -1615,6 +1619,26 @@ void ServerMainComponent::repaint_data_and_soft_key_mask()
 	dataMaskRenderer.on_change_active_mask(activeWorkingSet);
 	softKeyMaskRenderer.on_change_active_mask(activeWorkingSet);
 	workingSetSelector.redraw();
+}
+
+bool ServerMainComponent::is_active_alarm_mask() const
+{
+	for (const auto &ws : managedWorkingSetList)
+	{
+		if ((nullptr != ws->get_control_function()) &&
+		    (activeWorkingSetMasterAddress == ws->get_control_function()->get_address()))
+		{
+			auto activeMask = ws->get_object_by_id(activeWorkingSetDataMaskObjectID);
+			return (nullptr != activeMask) && (isobus::VirtualTerminalObjectType::AlarmMask == activeMask->get_object_type());
+		}
+	}
+
+	return false;
+}
+
+void ServerMainComponent::update_ack_button_visibility()
+{
+	workingSetSelector.set_ack_button_visible(showAckButton && is_active_alarm_mask());
 }
 
 void ServerMainComponent::check_load_settings(std::shared_ptr<ValueTree> settings)
@@ -1798,7 +1822,7 @@ void ServerMainComponent::check_load_settings(std::shared_ptr<ValueTree> setting
 		child = settings->getChild(index);
 	}
 
-	workingSetSelector.set_ack_button_visible(showAckButton);
+	update_ack_button_visibility();
 
 	if (!autostart)
 	{

--- a/src/WorkingSetSelectorComponent.cpp
+++ b/src/WorkingSetSelectorComponent.cpp
@@ -9,11 +9,49 @@
 #include "WorkingSetLoadingIndicatorComponent.hpp"
 #include "isobus/utility/system_timing.hpp"
 
+WorkingSetSelectorComponent::AckButton::AckButton() :
+  juce::TextButton("ACK")
+{
+}
+
+void WorkingSetSelectorComponent::AckButton::paintButton(juce::Graphics &g, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown)
+{
+	auto backgroundColour = findColour(getToggleState() ? juce::TextButton::buttonOnColourId : juce::TextButton::buttonColourId);
+	getLookAndFeel().drawButtonBackground(g, *this, backgroundColour, shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+	g.setColour(juce::Colours::deepskyblue.withAlpha(0.75f));
+	g.drawRoundedRectangle(getLocalBounds().toFloat().reduced(2.0f), 4.0f, 4.0f);
+
+	auto textBounds = getLocalBounds().withSizeKeepingCentre(juce::roundToInt(static_cast<float>(getWidth()) * LABEL_WIDTH_RATIO), getHeight());
+	juce::Font font(juce::FontOptions(1.0f));
+	juce::GlyphArrangement glyphs;
+	glyphs.addLineOfText(font, getButtonText(), 0.0f, 0.0f);
+	const auto textWidthAtUnitHeight = glyphs.getBoundingBox(0, -1, true).getWidth();
+	if (textWidthAtUnitHeight > 0.0f)
+	{
+		font.setHeight(static_cast<float>(textBounds.getWidth()) / textWidthAtUnitHeight);
+	}
+	font.setHeight(std::min(font.getHeight(), static_cast<float>(textBounds.getHeight()) * LABEL_WIDTH_RATIO));
+
+	g.setColour(findColour(getToggleState() ? juce::TextButton::textColourOnId : juce::TextButton::textColourOffId));
+	g.setFont(font);
+	g.drawText(getButtonText(), textBounds, juce::Justification::centred, false);
+}
+
 WorkingSetSelectorComponent::WorkingSetSelectorComponent(ServerMainComponent &server) :
   parentServer(server)
 {
 	setOpaque(false);
 	setBounds(0, 0, WIDTH, server.minimum_height());
+	ackButton.onStateChange = [this]() {
+		const auto isPressed = ackButton.isDown();
+		if (ackButtonPressed != isPressed)
+		{
+			ackButtonPressed = isPressed;
+			parentServer.send_alarm_ack_command(isPressed ? isobus::VirtualTerminalBase::KeyActivationCode::ButtonPressedOrLatched : isobus::VirtualTerminalBase::KeyActivationCode::ButtonUnlatchedOrReleased);
+		}
+	};
+	addAndMakeVisible(ackButton);
+	ackButton.setVisible(false);
 }
 
 void WorkingSetSelectorComponent::update_drawn_working_sets(std::vector<std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet>> &managedWorkingSetList)
@@ -34,6 +72,7 @@ void WorkingSetSelectorComponent::update_drawn_working_sets(std::vector<std::sha
 		}
 	}
 
+	ackButton.toFront(false);
 	repaint();
 }
 
@@ -61,6 +100,7 @@ void WorkingSetSelectorComponent::paint(Graphics &g)
 void WorkingSetSelectorComponent::resized()
 {
 	setBounds(0, 0, WIDTH, parentServer.minimum_height());
+	update_ack_button_bounds();
 }
 
 void WorkingSetSelectorComponent::redraw()
@@ -73,6 +113,7 @@ void WorkingSetSelectorComponent::redraw()
 		workingSetIndex++;
 	}
 	repaint();
+	ackButton.toFront(false);
 }
 
 void WorkingSetSelectorComponent::update_iop_load_indicators()
@@ -88,6 +129,19 @@ void WorkingSetSelectorComponent::update_iop_load_indicators()
 			}
 		}
 	}
+}
+
+void WorkingSetSelectorComponent::set_ack_button_visible(bool shouldBeVisible)
+{
+	if (!shouldBeVisible && ackButtonPressed)
+	{
+		ackButtonPressed = false;
+		parentServer.send_alarm_ack_command(isobus::VirtualTerminalBase::KeyActivationCode::ButtonUnlatchedOrReleased);
+	}
+	ackButton.setVisible(shouldBeVisible);
+	update_ack_button_bounds();
+	ackButton.toFront(false);
+	repaint();
 }
 
 constexpr int WorkingSetSelectorComponent::button_padding()
@@ -110,6 +164,13 @@ std::shared_ptr<Component> WorkingSetSelectorComponent::getWorkingSetChildCompon
 	workingSetComponent->setTopLeftPosition(button_padding(), button_padding() + workingSetIndex * (BUTTON_HEIGHT + button_padding()));
 	addAndMakeVisible(*workingSetComponent);
 	return workingSetComponent;
+}
+
+void WorkingSetSelectorComponent::update_ack_button_bounds()
+{
+	const auto ackButtonSize = BUTTON_WIDTH;
+	const auto ackButtonY = std::max(0, getHeight() - ackButtonSize - button_padding());
+	ackButton.setBounds(button_padding(), ackButtonY, ackButtonSize, ackButtonSize);
 }
 
 void WorkingSetSelectorComponent::mouseUp(const MouseEvent &event)


### PR DESCRIPTION
I have added an option for having a permanent dedicated ACK key in the bottom of the working set selector:
<img width="821" height="525" alt="kép" src="https://github.com/user-attachments/assets/13e4bfe0-ad5a-4ed2-918e-3239b671b5f4" />

This can came handy when operating a touchscreen only environment. (No keyboard.)

I have renamed the Shortcuts menu to ACK button, as the only shortcut what we had now is the ACK key.