### PR TITLE
Fix ETP configuration and limit DPO transfer bursts

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -36,9 +36,12 @@ AgISOVirtualTerminalApplication::MainWindow::MainWindow(juce::String name,
 	jassert(!canDrivers.empty()); // You need some kind of CAN interface to run this program!
 	isobus::CANHardwareInterface::set_number_of_can_channels(1);
 
-	auto config = isobus::CANNetworkManager::CANNetwork.get_configuration();
+	auto &config = isobus::CANNetworkManager::CANNetwork.get_configuration();
 	config.set_max_number_transport_protocol_sessions(256);
-	config.set_number_of_packets_per_dpo_message(255);
+	// A full 255-packet ETP burst can delay the following CTS long enough for
+	// some implement ECUs to time out. Keep a larger-than-default window while
+	// leaving enough time for the receiver to process each burst.
+	config.set_number_of_packets_per_dpo_message(64);
 	config.set_number_of_packets_per_cts_message(255);
 
 #ifndef JUCE_WINDOWS


### PR DESCRIPTION
## Summary

- apply CAN network settings to the actual configuration object instead of a copy
- limit ETP DPO bursts to 64 packets
- retain the increased transport-session and CTS limits

## Problem

Large VT object pools could not be transferred reliably. The existing configuration was copied, so the requested transport settings were never applied. After correcting that, 255-packet DPO bursts still caused some implement ECUs to time out before the following CTS exchange.

## Validation

Tested with a real implement ECU and a 958,121-byte object pool over PCAN:

- default effective 16-packet DPO window: transfer aborted around 47% with ETP timeout
- 255-packet DPO window: ECU accepted each burst but timed out waiting for the next transfer exchange
- 64-packet DPO window: transfer completed to 100% and the object pool rendered

Also built successfully in Release mode on Windows with Visual Studio 2022.