### PR TITLE
Send End of Object Pool response after additional IOP transfer

### DIFF
--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -12,6 +12,7 @@
 #include "isobus/isobus/isobus_virtual_terminal_server.hpp"
 
 #include <filesystem>
+#include <set>
 
 class ServerMainComponent : public juce::Component
   , public juce::KeyListener
@@ -212,6 +213,7 @@ private:
 	std::vector<std::shared_ptr<isobus::CANHardwarePlugin>> &parentCANDrivers;
 	std::vector<HeldButtonData> heldButtons;
 	std::set<std::string> loadedNames;
+	std::set<const isobus::VirtualTerminalServerManagedWorkingSet *> loadVersionResponsesSent;
 	std::uint32_t alarmAckKeyMaskId = isobus::NULL_OBJECT_ID;
 	int alarmAckKeyCode = juce::KeyPress::escapeKey;
 	std::uint8_t vtNumber = 1; // VT number in the range of 1-32

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -544,7 +544,13 @@ void ServerMainComponent::timerCallback()
 				change_selected_working_set(wsIndex);
 			}
 
-			if (ws->get_was_object_pool_loaded_from_non_volatile_memory())
+			// A Load Version response is only valid for the initial pool restored
+			// from non-volatile memory. A subsequently transferred IOP component
+			// must receive the normal End of Object Pool response.
+			const bool isInitialNonVolatileLoadResponse =
+			  ws->get_was_object_pool_loaded_from_non_volatile_memory() &&
+			  loadVersionResponsesSent.insert(ws.get()).second;
+			if (isInitialNonVolatileLoadResponse)
 			{
 				send_load_version_response(0, ws->get_control_function());
 			}
@@ -561,7 +567,10 @@ void ServerMainComponent::timerCallback()
 		{
 			ws->join_parsing_thread();
 
-			if (ws->get_was_object_pool_loaded_from_non_volatile_memory())
+			const bool isInitialNonVolatileLoadResponse =
+			  ws->get_was_object_pool_loaded_from_non_volatile_memory() &&
+			  loadVersionResponsesSent.insert(ws.get()).second;
+			if (isInitialNonVolatileLoadResponse)
 			{
 				send_load_version_response(1, ws->get_control_function());
 			}
@@ -1994,6 +2003,7 @@ int ServerMainComponent::minimum_height() const
 
 void ServerMainComponent::remove_working_set(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSetToRemove)
 {
+	loadVersionResponsesSent.erase(workingSetToRemove.get());
 	for (auto it = managedWorkingSetList.begin(); it != managedWorkingSetList.end(); it++)
 	{
 		if (workingSetToRemove == *it)


### PR DESCRIPTION
## Summary

Send `LoadVersionResponse` only for the initial object pool restored from non-volatile memory. Any additional IOP component transferred by the ECU receives the normal `EndOfObjectPoolResponse`.

## Problem

The `was_object_pool_loaded_from_non_volatile_memory` flag remains true for the working set. If an ECU successfully loads a stored version and then transfers an additional IOP component, the VT currently responds to that transfer with another `LoadVersionResponse`. The ECU then waits for `EndOfObjectPoolResponse`, does not activate its masks, and may reconnect.

## Validation

Observed and verified with a real implement ECU:

1. ECU sent Load Version and received a successful response.
2. ECU transferred an additional 22-byte IOP component and sent End of Object Pool.
3. Before this change, the VT sent a second Load Version response.
4. With this change, the VT sent a successful End of Object Pool response and the ECU immediately activated its object masks.

Built successfully in Release mode on Windows with Visual Studio 2022.