### PR TITLE
Show CAN adapter connection status next to the menu bar

### DIFF
--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -191,6 +191,7 @@ private:
 	void remove_working_set(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSetToRemove);
 	void clear_iso_data();
 
+	static constexpr int CAN_STATUS_INDICATOR_WIDTH = 150;
 	const std::string ISO_DATA_PATH = "iso_data";
 	std::string screenCaptureDirArgument = "";
 	std::string canLogPath;
@@ -220,6 +221,8 @@ private:
 	std::uint8_t numberOfPoolsToRender = 0;
 	VTVersion versionToReport = VTVersion::Version5;
 	bool needToRepaint = false;
+	bool canAdapterConnected = false;
+	bool canInterfaceRunning = false;
 	bool autostart = false;
 	bool hasStartBeenCalled = false;
 	bool alarmAckKeyPressed = false;

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -525,6 +525,17 @@ void ServerMainComponent::timerCallback()
 		statusMessageTimestamp_ms = isobus::SystemTiming::get_timestamp_ms();
 	}
 
+	auto activeCANDriver = isobus::CANHardwareInterface::get_assigned_can_channel_frame_handler(0);
+	bool isAdapterConnected = (nullptr != activeCANDriver) && activeCANDriver->get_is_valid();
+	bool isInterfaceRunning = isobus::CANHardwareInterface::is_running();
+
+	if ((isAdapterConnected != canAdapterConnected) || (isInterfaceRunning != canInterfaceRunning))
+	{
+		canAdapterConnected = isAdapterConnected;
+		canInterfaceRunning = isInterfaceRunning;
+		repaint(getWidth() - CAN_STATUS_INDICATOR_WIDTH, 0, CAN_STATUS_INDICATOR_WIDTH, juce::LookAndFeel::getDefaultLookAndFeel().getDefaultMenuBarHeight());
+	}
+
 	bool hasIopLoadInProgress = false;
 	int wsIndex = 0;
 	for (auto &ws : managedWorkingSetList)
@@ -682,8 +693,26 @@ void ServerMainComponent::paint(juce::Graphics &g)
 	// (Our component is opaque, so we must completely fill the background with a solid colour)
 	g.fillAll(getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
 
-	// You can add your drawing code here!
-	//workingSetSelector->paint(g);
+	auto statusArea = juce::Rectangle<int>(getWidth() - CAN_STATUS_INDICATOR_WIDTH, 0, CAN_STATUS_INDICATOR_WIDTH, juce::LookAndFeel::getDefaultLookAndFeel().getDefaultMenuBarHeight());
+	{
+		juce::Graphics::ScopedSaveState backgroundState(g);
+		g.setOrigin(statusArea.getPosition());
+		getLookAndFeel().drawMenuBarBackground(g, statusArea.getWidth(), statusArea.getHeight(), false, menuBar);
+	}
+
+	auto statusColour = juce::Colours::grey;
+	juce::String statusText = "CAN Stopped";
+
+	if (canInterfaceRunning)
+	{
+		statusColour = canAdapterConnected ? juce::Colours::limegreen : juce::Colours::red;
+		statusText = canAdapterConnected ? "CAN Connected" : "CAN Disconnected";
+	}
+	g.setColour(statusColour);
+	g.fillEllipse(statusArea.removeFromLeft(statusArea.getHeight()).reduced(7).toFloat());
+	g.setColour(getLookAndFeel().findColour(juce::Label::textColourId));
+	g.setFont(14.0f);
+	g.drawText(statusText, statusArea, juce::Justification::centredLeft);
 }
 
 void ServerMainComponent::resized()
@@ -705,7 +734,7 @@ void ServerMainComponent::resized()
 	                              2 * SoftKeyMaskDimensions::PADDING + get_physical_soft_key_columns() * (SoftKeyMaskDimensions::PADDING + get_soft_key_descriptor_y_pixel_height()),
 	                              get_data_mask_area_size_y_pixels());
 	loggerViewport.setTopLeftPosition(0, minimum_height());
-	menuBar.setBounds(lBounds.removeFromTop(lMenuBarHeight));
+	menuBar.setBounds(lBounds.removeFromTop(lMenuBarHeight).withTrimmedRight(CAN_STATUS_INDICATOR_WIDTH));
 	logger.setSize(loggerViewport.getWidth(), logger.getHeight());
 
 	if (logger.getHeight() < loggerViewport.getHeight())


### PR DESCRIPTION
## Describe your changes

Adds a status indicator (colored dot + label) next to the menu bar showing whether the CAN adapter is connected, disconnected, or the interface hasn't been started.

Closes #160

## Approach

- `ServerMainComponent::timerCallback()` polls `CANHardwareInterface::is_running()` and the active driver's `get_is_valid()`, and only repaints the indicator area when the state changes
- Grey = interface not started/interface stopped, green = adapter connected, red = interface running but the adapter is unusable (e.g. link down, device unplugged)

## Validation

I didn't see any existing test infrastructure in this repo (BUILD_TESTING is forced off), so I'm not sure whether unit tests are expected for changes like this — happy to add one if there's a preferred approach. For now this was validated manually against a SocketCAN vcan interface with an AgIsoStack++ client connected: verified grey on startup, green once started with the client uploading its object pool, and red after taking the link down mid-session (state updates within ~1s, matching the VT's status message interval).


<img width="668" height="319" alt="image" src="https://github.com/user-attachments/assets/edcabbcd-d65c-4836-86c4-78d69c8c1b77" />
<img width="667" height="641" alt="image" src="https://github.com/user-attachments/assets/6954455c-ec6d-4db5-8e68-ea56451c3b8b" />
