### PR TITLE
Add a diagnostics window for active DTCs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ target_sources(
           "src/InputBooleanComponent.cpp"
           "src/LoggerComponent.cpp"
           "src/DiagnosticsComponent.cpp"
+          "src/DiagnosticsWindow.cpp"
           "src/InputNumberComponent.cpp"
           "src/OutputEllipseComponent.cpp"
           "src/OutputLineComponent.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ target_sources(
           "src/OutputMeterComponent.cpp"
           "src/InputBooleanComponent.cpp"
           "src/LoggerComponent.cpp"
+          "src/DiagnosticsComponent.cpp"
           "src/InputNumberComponent.cpp"
           "src/OutputEllipseComponent.cpp"
           "src/OutputLineComponent.cpp"

--- a/include/DiagnosticsComponent.hpp
+++ b/include/DiagnosticsComponent.hpp
@@ -19,9 +19,11 @@
 
 /// @brief Defines a GUI component that lists active DTCs (DM1) grouped per source control function
 class DiagnosticsComponent : public Component
+  , private Timer
 {
 public:
 	DiagnosticsComponent();
+	~DiagnosticsComponent() override;
 
 	void paint(Graphics &g) override;
 	void update_content_height();
@@ -44,13 +46,16 @@ private:
 		std::string manufacturerName;
 		std::uint8_t lampStatus;
 		std::uint8_t lampFlash;
+		std::uint32_t lastSeenTimestamp;
 		std::vector<ActiveDTC> activeDTCs;
 	};
 
 	/// @brief Decodes a received DM1 message and updates the DTC list of its source control function
 	static void process_dm1_message(const isobus::CANMessage &message, void *parent);
+	void timerCallback() override;
 
 	static constexpr int LINE_HEIGHT = 20;
+	static constexpr std::uint32_t STALE_TIMEOUT_MS = 7000;
 
 	std::map<std::uint64_t, SourceEntry> sources;
 

--- a/include/DiagnosticsComponent.hpp
+++ b/include/DiagnosticsComponent.hpp
@@ -57,6 +57,9 @@ private:
 
 	static constexpr int LINE_HEIGHT = 20;
 	static constexpr float FONT_HEIGHT = 17.0f;
+	static constexpr int SPN_COLUMN_X = 16;
+	static constexpr int FMI_COLUMN_X = 120;
+	static constexpr int COUNT_COLUMN_X = 190;
 	static constexpr std::uint32_t STALE_TIMEOUT_MS = 7000;
 
 	std::map<std::uint64_t, SourceEntry> sources;

--- a/include/DiagnosticsComponent.hpp
+++ b/include/DiagnosticsComponent.hpp
@@ -22,9 +22,9 @@ class DiagnosticsComponent : public Component
 {
 public:
 	DiagnosticsComponent();
-	~DiagnosticsComponent() override;
 
 	void paint(Graphics &g) override;
+	void update_content_height();
 
 	static constexpr int WIDTH = 260;
 
@@ -50,7 +50,7 @@ private:
 	/// @brief Decodes a received DM1 message and updates the DTC list of its source control function
 	static void process_dm1_message(const isobus::CANMessage &message, void *parent);
 
-	static constexpr int LINE_HEIGHT = 14;
+	static constexpr int LINE_HEIGHT = 20;
 
 	std::map<std::uint64_t, SourceEntry> sources;
 

--- a/include/DiagnosticsComponent.hpp
+++ b/include/DiagnosticsComponent.hpp
@@ -1,0 +1,58 @@
+//================================================================================================
+/// @file DiagnosticsComponent.hpp
+///
+/// @brief Defines a GUI component to display active diagnostic trouble codes (DM1)
+/// reported by control functions on the bus.
+/// @author Sujan Dumaru
+///
+/// @copyright 2026 The Open-Agriculture Developers
+//================================================================================================
+#pragma once
+
+#include "isobus/isobus/can_message.hpp"
+
+#include "JuceHeader.h"
+
+#include <map>
+#include <string>
+#include <vector>
+
+/// @brief Defines a GUI component that lists active DTCs (DM1) grouped per source control function
+class DiagnosticsComponent : public Component
+{
+public:
+	DiagnosticsComponent();
+	~DiagnosticsComponent() override;
+
+	void paint(Graphics &g) override;
+
+	static constexpr int WIDTH = 260;
+
+private:
+	/// @brief One decoded DTC from a DM1 message
+	struct ActiveDTC
+	{
+		std::uint32_t suspectParameterNumber;
+		std::uint8_t failureModeIdentifier;
+		std::uint8_t occurrenceCount;
+	};
+
+	/// @brief The diagnostic state most recently reported by one source control function
+	struct SourceEntry
+	{
+		std::uint8_t address;
+		std::string manufacturerName;
+		std::uint8_t lampStatus;
+		std::uint8_t lampFlash;
+		std::vector<ActiveDTC> activeDTCs;
+	};
+
+	/// @brief Decodes a received DM1 message and updates the DTC list of its source control function
+	static void process_dm1_message(const isobus::CANMessage &message, void *parent);
+
+	static constexpr int LINE_HEIGHT = 14;
+
+	std::map<std::uint64_t, SourceEntry> sources;
+
+	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DiagnosticsComponent)
+};

--- a/include/DiagnosticsComponent.hpp
+++ b/include/DiagnosticsComponent.hpp
@@ -52,9 +52,11 @@ private:
 
 	/// @brief Decodes a received DM1 message and updates the DTC list of its source control function
 	static void process_dm1_message(const isobus::CANMessage &message, void *parent);
+	static TextLayout source_summary_layout(const SourceEntry &entry, int width);
 	void timerCallback() override;
 
 	static constexpr int LINE_HEIGHT = 20;
+	static constexpr float FONT_HEIGHT = 17.0f;
 	static constexpr std::uint32_t STALE_TIMEOUT_MS = 7000;
 
 	std::map<std::uint64_t, SourceEntry> sources;

--- a/include/DiagnosticsWindow.hpp
+++ b/include/DiagnosticsWindow.hpp
@@ -20,6 +20,7 @@ public:
 	explicit DiagnosticsWindow(ServerMainComponent &parentComponent);
 
 	void closeButtonPressed() override;
+	void resized() override;
 
 	ServerMainComponent &parentServer;
 

--- a/include/DiagnosticsWindow.hpp
+++ b/include/DiagnosticsWindow.hpp
@@ -1,0 +1,31 @@
+//================================================================================================
+/// @file DiagnosticsWindow.hpp
+///
+/// @brief Defines a separate window that shows active diagnostic trouble codes (DM1)
+/// reported by control functions on the bus.
+/// @author Sujan Dumaru
+///
+/// @copyright 2026 The Open-Agriculture Developers
+//================================================================================================
+#pragma once
+
+#include "DiagnosticsComponent.hpp"
+
+class ServerMainComponent;
+
+/// @brief A window hosting the diagnostics component, opened from the menu bar
+class DiagnosticsWindow : public DocumentWindow
+{
+public:
+	explicit DiagnosticsWindow(ServerMainComponent &parentComponent);
+
+	void closeButtonPressed() override;
+
+	ServerMainComponent &parentServer;
+
+private:
+	DiagnosticsComponent content;
+	Viewport viewport;
+
+	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DiagnosticsWindow)
+};

--- a/include/ServerMainComponent.hpp
+++ b/include/ServerMainComponent.hpp
@@ -2,6 +2,7 @@
 
 #include "ConfigureHardwareWindow.hpp"
 #include "DataMaskRenderAreaComponent.hpp"
+#include "DiagnosticsWindow.hpp"
 #include "LoggerComponent.hpp"
 #include "SoftKeyMaskComponent.hpp"
 #include "SoftKeyMaskRenderAreaComponent.hpp"
@@ -125,6 +126,8 @@ public:
 
 	void save_settings();
 
+	void show_diagnostics_window();
+
 	void identify_vt() override;
 
 	void screen_capture(std::uint8_t item, std::uint8_t path, std::shared_ptr<isobus::ControlFunction> requestor) override;
@@ -151,7 +154,8 @@ private:
 		ClearISOData,
 		ConfigureCANHardware,
 		StartStop,
-		AutoStart
+		AutoStart,
+		ShowDiagnostics
 	};
 
 	SoftKeyMaskDimensions softKeyMaskDimensions;
@@ -161,8 +165,6 @@ private:
 	public:
 		void operator()(int result) const noexcept;
 		ServerMainComponent &mParent;
-
-	private:
 	};
 	friend class LanguageCommandConfigClosed;
 
@@ -210,6 +212,7 @@ private:
 	std::unique_ptr<isobus::DiagnosticProtocol> diagnosticProtocol;
 	std::unique_ptr<AlertWindow> popupMenu;
 	std::unique_ptr<ConfigureHardwareWindow> configureHardwareWindow;
+	std::unique_ptr<DiagnosticsWindow> diagnosticsWindow;
 	std::shared_ptr<isobus::ControlFunction> alarmAckKeyWs;
 	std::vector<std::shared_ptr<isobus::CANHardwarePlugin>> &parentCANDrivers;
 	std::vector<HeldButtonData> heldButtons;

--- a/src/DiagnosticsComponent.cpp
+++ b/src/DiagnosticsComponent.cpp
@@ -14,35 +14,36 @@
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 
-/// @brief Returns a short label for the lamps a DM1 message reports as on
+/// @brief Returns coloured labels for the lamps a DM1 message reports as on
 /// @param[in] lampStatus The first byte of the DM1 payload (lamp status)
 /// @param[in] lampFlash The second byte of the DM1 payload (lamp flash)
-static String lamp_summary(std::uint8_t lampStatus, std::uint8_t lampFlash)
+/// @param[in] font The font used to render each lamp label
+static AttributedString lamp_summary(std::uint8_t lampStatus, std::uint8_t lampFlash, const Font &font)
 {
-	String retVal;
+	AttributedString retVal;
 
 	if ((0xFF == lampStatus) && (0xFF == lampFlash))
 	{
 		// ISO 11783 mode sends 0xFF for both lamp bytes, meaning "not available"
-		retVal = " [LAMPS N/A]";
+		retVal.append(" [LAMPS N/A]", font, Colours::grey);
 	}
 	else
 	{
 		if (0x01 == ((lampStatus >> 6) & 0x03))
 		{
-			retVal += " [MIL]";
+			retVal.append(" [MIL]", font, Colours::orange);
 		}
 		if (0x01 == ((lampStatus >> 4) & 0x03))
 		{
-			retVal += " [STOP]";
+			retVal.append(" [STOP]", font, Colours::red);
 		}
 		if (0x01 == ((lampStatus >> 2) & 0x03))
 		{
-			retVal += " [WARN]";
+			retVal.append(" [WARN]", font, Colours::yellow);
 		}
 		if (0x01 == (lampStatus & 0x03))
 		{
-			retVal += " [PROTECT]";
+			retVal.append(" [PROTECT]", font, Colours::orange);
 		}
 	}
 	return retVal;
@@ -61,10 +62,24 @@ DiagnosticsComponent::~DiagnosticsComponent()
 	isobus::CANNetworkManager::CANNetwork.remove_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::DiagnosticMessage1), process_dm1_message, this);
 }
 
+TextLayout DiagnosticsComponent::source_summary_layout(const SourceEntry &entry, int width)
+{
+	const Font diagnosticsFont{ FontOptions(FONT_HEIGHT) };
+	AttributedString sourceSummary;
+	sourceSummary.setWordWrap(AttributedString::WordWrap::byWord);
+	sourceSummary.setJustification(Justification::centredLeft);
+	sourceSummary.append(String("#" + std::to_string(entry.address) + " " + entry.manufacturerName), diagnosticsFont, Colours::white);
+	sourceSummary.append(lamp_summary(entry.lampStatus, entry.lampFlash, diagnosticsFont));
+
+	TextLayout retVal;
+	retVal.createLayout(sourceSummary, static_cast<float>(jmax(1, width - 4)));
+	return retVal;
+}
+
 void DiagnosticsComponent::paint(Graphics &g)
 {
 	g.fillAll(Colours::black);
-	g.setFont(16.0f);
+	g.setFont(FONT_HEIGHT);
 
 	if (sources.empty())
 	{
@@ -79,9 +94,10 @@ void DiagnosticsComponent::paint(Graphics &g)
 	{
 		const auto &entry = source.second;
 
-		g.setColour(Colours::white);
-		g.drawFittedText(String("#" + std::to_string(entry.address) + " " + entry.manufacturerName) + lamp_summary(entry.lampStatus, entry.lampFlash), 4, line * LINE_HEIGHT, getWidth() - 4, LINE_HEIGHT, Justification::centredLeft, 1);
-		line++;
+		const auto sourceLayout = source_summary_layout(entry, getWidth());
+		const auto sourceHeight = jmax(1, sourceLayout.getNumLines()) * LINE_HEIGHT;
+		sourceLayout.draw(g, Rectangle<float>(4.0f, static_cast<float>(line * LINE_HEIGHT), static_cast<float>(getWidth() - 4), static_cast<float>(sourceHeight)));
+		line += sourceHeight / LINE_HEIGHT;
 
 		g.setColour(Colours::yellow);
 
@@ -99,7 +115,7 @@ void DiagnosticsComponent::update_content_height()
 
 	for (const auto &source : sources)
 	{
-		numberOfLines += 1 + static_cast<int>(source.second.activeDTCs.size());
+		numberOfLines += jmax(1, source_summary_layout(source.second, getWidth()).getNumLines()) + static_cast<int>(source.second.activeDTCs.size());
 	}
 
 	int newHeight = numberOfLines * LINE_HEIGHT;

--- a/src/DiagnosticsComponent.cpp
+++ b/src/DiagnosticsComponent.cpp
@@ -24,23 +24,26 @@ static String lamp_summary(std::uint8_t lampStatus, std::uint8_t lampFlash)
 	if ((0xFF == lampStatus) && (0xFF == lampFlash))
 	{
 		// ISO 11783 mode sends 0xFF for both lamp bytes, meaning "not available"
-		return retVal;
+		retVal = " [LAMPS N/A]";
 	}
-	if (0x01 == ((lampStatus >> 6) & 0x03))
+	else
 	{
-		retVal += " [MIL]";
-	}
-	if (0x01 == ((lampStatus >> 4) & 0x03))
-	{
-		retVal += " [STOP]";
-	}
-	if (0x01 == ((lampStatus >> 2) & 0x03))
-	{
-		retVal += " [WARN]";
-	}
-	if (0x01 == (lampStatus & 0x03))
-	{
-		retVal += " [PROTECT]";
+		if (0x01 == ((lampStatus >> 6) & 0x03))
+		{
+			retVal += " [MIL]";
+		}
+		if (0x01 == ((lampStatus >> 4) & 0x03))
+		{
+			retVal += " [STOP]";
+		}
+		if (0x01 == ((lampStatus >> 2) & 0x03))
+		{
+			retVal += " [WARN]";
+		}
+		if (0x01 == (lampStatus & 0x03))
+		{
+			retVal += " [PROTECT]";
+		}
 	}
 	return retVal;
 }

--- a/src/DiagnosticsComponent.cpp
+++ b/src/DiagnosticsComponent.cpp
@@ -62,7 +62,7 @@ DiagnosticsComponent::~DiagnosticsComponent()
 void DiagnosticsComponent::paint(Graphics &g)
 {
 	g.fillAll(Colours::black);
-	g.setFont(14.0f);
+	g.setFont(16.0f);
 
 	if (sources.empty())
 	{
@@ -89,6 +89,26 @@ void DiagnosticsComponent::paint(Graphics &g)
 			line++;
 		}
 	}
+}
+
+void DiagnosticsComponent::update_content_height()
+{
+	int numberOfLines = sources.empty() ? 1 : 0;
+
+	for (const auto &source : sources)
+	{
+		numberOfLines += 1 + static_cast<int>(source.second.activeDTCs.size());
+	}
+
+	int newHeight = numberOfLines * LINE_HEIGHT;
+	auto *parentViewport = findParentComponentOfClass<Viewport>();
+
+	if (nullptr != parentViewport)
+	{
+		newHeight = jmax(newHeight, parentViewport->getMaximumVisibleHeight());
+	}
+	setSize(getWidth(), newHeight);
+	repaint();
 }
 
 void DiagnosticsComponent::process_dm1_message(const isobus::CANMessage &message, void *parent)
@@ -135,7 +155,6 @@ void DiagnosticsComponent::process_dm1_message(const isobus::CANMessage &message
 	}
 
 	const auto mmLock = MessageManagerLock();
-	auto bounds = component->getLocalBounds();
 
 	if (entry.activeDTCs.empty())
 	{
@@ -145,20 +164,5 @@ void DiagnosticsComponent::process_dm1_message(const isobus::CANMessage &message
 	{
 		component->sources[source->get_NAME().get_full_name()] = std::move(entry);
 	}
-
-	int numberOfLines = 0;
-
-	for (const auto &existingSource : component->sources)
-	{
-		numberOfLines += 1 + static_cast<int>(existingSource.second.activeDTCs.size());
-	}
-
-	int newSize = numberOfLines * LINE_HEIGHT;
-
-	if (newSize < component->getHeight())
-	{
-		newSize = component->getHeight();
-	}
-	component->setSize(bounds.getWidth(), newSize);
-	component->repaint();
+	component->update_content_height();
 }

--- a/src/DiagnosticsComponent.cpp
+++ b/src/DiagnosticsComponent.cpp
@@ -52,10 +52,12 @@ DiagnosticsComponent::DiagnosticsComponent()
 {
 	setSize(WIDTH, LINE_HEIGHT);
 	isobus::CANNetworkManager::CANNetwork.add_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::DiagnosticMessage1), process_dm1_message, this);
+	startTimer(1000);
 }
 
 DiagnosticsComponent::~DiagnosticsComponent()
 {
+	stopTimer();
 	isobus::CANNetworkManager::CANNetwork.remove_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::DiagnosticMessage1), process_dm1_message, this);
 }
 
@@ -130,6 +132,7 @@ void DiagnosticsComponent::process_dm1_message(const isobus::CANMessage &message
 	entry.address = source->get_address();
 	entry.lampStatus = data.at(0);
 	entry.lampFlash = data.at(1);
+	entry.lastSeenTimestamp = Time::getMillisecondCounter();
 
 	if (manufacturerMap.find(source->get_NAME().get_manufacturer_code()) != manufacturerMap.end())
 	{
@@ -165,4 +168,28 @@ void DiagnosticsComponent::process_dm1_message(const isobus::CANMessage &message
 		component->sources[source->get_NAME().get_full_name()] = std::move(entry);
 	}
 	component->update_content_height();
+}
+
+void DiagnosticsComponent::timerCallback()
+{
+	const auto currentTimestamp = Time::getMillisecondCounter();
+	bool removedSource = false;
+
+	for (auto source = sources.begin(); source != sources.end();)
+	{
+		if ((currentTimestamp - source->second.lastSeenTimestamp) >= STALE_TIMEOUT_MS)
+		{
+			source = sources.erase(source);
+			removedSource = true;
+		}
+		else
+		{
+			++source;
+		}
+	}
+
+	if (removedSource)
+	{
+		update_content_height();
+	}
 }

--- a/src/DiagnosticsComponent.cpp
+++ b/src/DiagnosticsComponent.cpp
@@ -99,11 +99,19 @@ void DiagnosticsComponent::paint(Graphics &g)
 		sourceLayout.draw(g, Rectangle<float>(4.0f, static_cast<float>(line * LINE_HEIGHT), static_cast<float>(getWidth() - 4), static_cast<float>(sourceHeight)));
 		line += sourceHeight / LINE_HEIGHT;
 
+		g.setColour(Colours::grey);
+		g.drawText("SPN", SPN_COLUMN_X, line * LINE_HEIGHT, FMI_COLUMN_X - SPN_COLUMN_X, LINE_HEIGHT, Justification::centredLeft);
+		g.drawText("FMI", FMI_COLUMN_X, line * LINE_HEIGHT, COUNT_COLUMN_X - FMI_COLUMN_X, LINE_HEIGHT, Justification::centredLeft);
+		g.drawText("Count", COUNT_COLUMN_X, line * LINE_HEIGHT, getWidth() - COUNT_COLUMN_X, LINE_HEIGHT, Justification::centredLeft);
+		line++;
+
 		g.setColour(Colours::yellow);
 
 		for (const auto &dtc : entry.activeDTCs)
 		{
-			g.drawFittedText("SPN " + std::to_string(dtc.suspectParameterNumber) + "  FMI " + std::to_string(dtc.failureModeIdentifier) + "  Count " + std::to_string(dtc.occurrenceCount), 16, line * LINE_HEIGHT, getWidth() - 16, LINE_HEIGHT, Justification::centredLeft, 1);
+			g.drawText(String(std::to_string(dtc.suspectParameterNumber)), SPN_COLUMN_X, line * LINE_HEIGHT, FMI_COLUMN_X - SPN_COLUMN_X, LINE_HEIGHT, Justification::centredLeft);
+			g.drawText(String(std::to_string(dtc.failureModeIdentifier)), FMI_COLUMN_X, line * LINE_HEIGHT, COUNT_COLUMN_X - FMI_COLUMN_X, LINE_HEIGHT, Justification::centredLeft);
+			g.drawText(String(std::to_string(dtc.occurrenceCount)), COUNT_COLUMN_X, line * LINE_HEIGHT, getWidth() - COUNT_COLUMN_X, LINE_HEIGHT, Justification::centredLeft);
 			line++;
 		}
 	}
@@ -115,7 +123,7 @@ void DiagnosticsComponent::update_content_height()
 
 	for (const auto &source : sources)
 	{
-		numberOfLines += jmax(1, source_summary_layout(source.second, getWidth()).getNumLines()) + static_cast<int>(source.second.activeDTCs.size());
+		numberOfLines += jmax(1, source_summary_layout(source.second, getWidth()).getNumLines()) + 1 + static_cast<int>(source.second.activeDTCs.size());
 	}
 
 	int newHeight = numberOfLines * LINE_HEIGHT;

--- a/src/DiagnosticsComponent.cpp
+++ b/src/DiagnosticsComponent.cpp
@@ -1,0 +1,161 @@
+//================================================================================================
+/// @file DiagnosticsComponent.cpp
+///
+/// @brief Implements a GUI component to display active diagnostic trouble codes (DM1)
+/// reported by control functions on the bus.
+/// @author Sujan Dumaru
+///
+/// @copyright The Open-Agriculture Developers
+//================================================================================================
+#include "DiagnosticsComponent.hpp"
+
+#include "ManufacturerMap.hpp"
+
+#include "isobus/isobus/can_general_parameter_group_numbers.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
+
+/// @brief Returns a short label for the lamps a DM1 message reports as on
+/// @param[in] lampStatus The first byte of the DM1 payload (lamp status)
+/// @param[in] lampFlash The second byte of the DM1 payload (lamp flash)
+static String lamp_summary(std::uint8_t lampStatus, std::uint8_t lampFlash)
+{
+	String retVal;
+
+	if ((0xFF == lampStatus) && (0xFF == lampFlash))
+	{
+		// ISO 11783 mode sends 0xFF for both lamp bytes, meaning "not available"
+		return retVal;
+	}
+	if (0x01 == ((lampStatus >> 6) & 0x03))
+	{
+		retVal += " [MIL]";
+	}
+	if (0x01 == ((lampStatus >> 4) & 0x03))
+	{
+		retVal += " [STOP]";
+	}
+	if (0x01 == ((lampStatus >> 2) & 0x03))
+	{
+		retVal += " [WARN]";
+	}
+	if (0x01 == (lampStatus & 0x03))
+	{
+		retVal += " [PROTECT]";
+	}
+	return retVal;
+}
+
+DiagnosticsComponent::DiagnosticsComponent()
+{
+	setSize(WIDTH, LINE_HEIGHT);
+	isobus::CANNetworkManager::CANNetwork.add_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::DiagnosticMessage1), process_dm1_message, this);
+}
+
+DiagnosticsComponent::~DiagnosticsComponent()
+{
+	isobus::CANNetworkManager::CANNetwork.remove_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::DiagnosticMessage1), process_dm1_message, this);
+}
+
+void DiagnosticsComponent::paint(Graphics &g)
+{
+	g.fillAll(Colours::black);
+	g.setFont(14.0f);
+
+	if (sources.empty())
+	{
+		g.setColour(Colours::grey);
+		g.drawFittedText("No active DTCs", 4, 0, getWidth() - 4, LINE_HEIGHT, Justification::centredLeft, 1);
+		return;
+	}
+
+	int line = 0;
+
+	for (const auto &source : sources)
+	{
+		const auto &entry = source.second;
+
+		g.setColour(Colours::white);
+		g.drawFittedText(String("#" + std::to_string(entry.address) + " " + entry.manufacturerName) + lamp_summary(entry.lampStatus, entry.lampFlash), 4, line * LINE_HEIGHT, getWidth() - 4, LINE_HEIGHT, Justification::centredLeft, 1);
+		line++;
+
+		g.setColour(Colours::yellow);
+
+		for (const auto &dtc : entry.activeDTCs)
+		{
+			g.drawFittedText("SPN " + std::to_string(dtc.suspectParameterNumber) + "  FMI " + std::to_string(dtc.failureModeIdentifier) + "  Count " + std::to_string(dtc.occurrenceCount), 16, line * LINE_HEIGHT, getWidth() - 16, LINE_HEIGHT, Justification::centredLeft, 1);
+			line++;
+		}
+	}
+}
+
+void DiagnosticsComponent::process_dm1_message(const isobus::CANMessage &message, void *parent)
+{
+	auto *component = static_cast<DiagnosticsComponent *>(parent);
+	auto source = message.get_source_control_function();
+	const auto &data = message.get_data();
+
+	if ((nullptr == component) ||
+	    (nullptr == source) ||
+	    (isobus::ControlFunction::Type::Internal == source->get_type()) ||
+	    (data.size() < 8))
+	{
+		// The VT's own DM1 broadcasts are not shown; the panel is for the other devices on the bus
+		return;
+	}
+
+	SourceEntry entry;
+	entry.address = source->get_address();
+	entry.lampStatus = data.at(0);
+	entry.lampFlash = data.at(1);
+
+	if (manufacturerMap.find(source->get_NAME().get_manufacturer_code()) != manufacturerMap.end())
+	{
+		entry.manufacturerName = manufacturerMap.at(source->get_NAME().get_manufacturer_code());
+	}
+
+	for (std::size_t offset = 2; (offset + 4) <= data.size(); offset += 4)
+	{
+		ActiveDTC dtc;
+		dtc.suspectParameterNumber = static_cast<std::uint32_t>(data.at(offset)) |
+		  (static_cast<std::uint32_t>(data.at(offset + 1)) << 8) |
+		  (static_cast<std::uint32_t>((data.at(offset + 2) & 0xE0) >> 5) << 16);
+		dtc.failureModeIdentifier = data.at(offset + 2) & 0x1F;
+		dtc.occurrenceCount = data.at(offset + 3) & 0x7F;
+
+		if (((0 == dtc.suspectParameterNumber) && (0 == dtc.failureModeIdentifier)) ||
+		    ((0x7FFFF == dtc.suspectParameterNumber) && (0x1F == dtc.failureModeIdentifier)))
+		{
+			// A DM1 with no active DTCs carries an all-zero DTC field; 0xFF padding decodes as all-ones
+			continue;
+		}
+		entry.activeDTCs.push_back(dtc);
+	}
+
+	const auto mmLock = MessageManagerLock();
+	auto bounds = component->getLocalBounds();
+
+	if (entry.activeDTCs.empty())
+	{
+		component->sources.erase(source->get_NAME().get_full_name());
+	}
+	else
+	{
+		component->sources[source->get_NAME().get_full_name()] = std::move(entry);
+	}
+
+	int numberOfLines = 0;
+
+	for (const auto &existingSource : component->sources)
+	{
+		numberOfLines += 1 + static_cast<int>(existingSource.second.activeDTCs.size());
+	}
+
+	int newSize = numberOfLines * LINE_HEIGHT;
+
+	if (newSize < component->getHeight())
+	{
+		newSize = component->getHeight();
+	}
+	component->setSize(bounds.getWidth(), newSize);
+	component->repaint();
+}

--- a/src/DiagnosticsWindow.cpp
+++ b/src/DiagnosticsWindow.cpp
@@ -1,0 +1,27 @@
+//================================================================================================
+/// @file DiagnosticsWindow.cpp
+///
+/// @brief Implements a separate window that shows active diagnostic trouble codes (DM1)
+/// reported by control functions on the bus.
+/// @author Sujan Dumaru
+///
+/// @copyright The Open-Agriculture Developers
+//================================================================================================
+#include "DiagnosticsWindow.hpp"
+
+DiagnosticsWindow::DiagnosticsWindow(ServerMainComponent &parentComponent) :
+  DocumentWindow("Diagnostics", juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId), DocumentWindow::closeButton),
+  parentServer(parentComponent)
+{
+	setOpaque(true);
+	setResizable(true, true);
+	setSize(DiagnosticsComponent::WIDTH + 40, 400);
+	content.setSize(DiagnosticsComponent::WIDTH, 400);
+	viewport.setViewedComponent(&content, false);
+	setContentNonOwned(&viewport, false);
+}
+
+void DiagnosticsWindow::closeButtonPressed()
+{
+	setVisible(false);
+}

--- a/src/DiagnosticsWindow.cpp
+++ b/src/DiagnosticsWindow.cpp
@@ -25,3 +25,10 @@ void DiagnosticsWindow::closeButtonPressed()
 {
 	setVisible(false);
 }
+
+void DiagnosticsWindow::resized()
+{
+	DocumentWindow::resized();
+	content.setSize(viewport.getMaximumVisibleWidth(), content.getHeight());
+	content.update_content_height();
+}

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -759,6 +759,7 @@ void ServerMainComponent::getAllCommands(juce::Array<juce::CommandID> &allComman
 	allCommands.add(static_cast<int>(CommandIDs::GenerateLogPackage));
 	allCommands.add(static_cast<int>(CommandIDs::GenerateLogPackageFromCurrentSession));
 	allCommands.add(static_cast<int>(CommandIDs::ClearISOData));
+	allCommands.add(static_cast<int>(CommandIDs::ShowDiagnostics));
 	allCommands.add(static_cast<int>(CommandIDs::StartStop));
 	allCommands.add(static_cast<int>(CommandIDs::AutoStart));
 #ifdef JUCE_WINDOWS
@@ -817,6 +818,12 @@ void ServerMainComponent::getCommandInfo(juce::CommandID commandID, ApplicationC
 		case CommandIDs::ClearISOData:
 		{
 			result.setInfo("Clear ISO Data", "Clears all saved ISO data", "Troubleshooting", 0);
+		}
+		break;
+
+		case CommandIDs::ShowDiagnostics:
+		{
+			result.setInfo("Diagnostics", "Show active diagnostic trouble codes from devices on the bus", "Troubleshooting", 0);
 		}
 		break;
 
@@ -1091,6 +1098,13 @@ bool ServerMainComponent::perform(const InvocationInfo &info)
 		}
 		break;
 
+		case static_cast<int>(CommandIDs::ShowDiagnostics):
+		{
+			show_diagnostics_window();
+			retVal = true;
+		}
+		break;
+
 		case static_cast<int>(CommandIDs::StartStop):
 		{
 			if (hasStartBeenCalled)
@@ -1196,6 +1210,7 @@ PopupMenu ServerMainComponent::getMenuForIndex(int index, const juce::String &)
 			retVal.addCommandItem(&mCommandManager, static_cast<int>(CommandIDs::GenerateLogPackage));
 			retVal.addCommandItem(&mCommandManager, static_cast<int>(CommandIDs::GenerateLogPackageFromCurrentSession));
 			retVal.addCommandItem(&mCommandManager, static_cast<int>(CommandIDs::ClearISOData));
+			retVal.addCommandItem(&mCommandManager, static_cast<int>(CommandIDs::ShowDiagnostics));
 		}
 		break;
 
@@ -1214,6 +1229,22 @@ PopupMenu ServerMainComponent::getMenuForIndex(int index, const juce::String &)
 void ServerMainComponent::menuItemSelected(int, int)
 {
 	// Do nothing
+}
+
+void ServerMainComponent::show_diagnostics_window()
+{
+	if (nullptr == diagnosticsWindow)
+	{
+		diagnosticsWindow = std::make_unique<DiagnosticsWindow>(*this);
+		diagnosticsWindow->addToDesktop();
+		Rectangle<int> area(0, 0, DiagnosticsComponent::WIDTH + 40, 400);
+		RectanglePlacement placement(RectanglePlacement::centred |
+		                             RectanglePlacement::doNotResize);
+		auto result = placement.appliedTo(area, Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea.reduced(20));
+		diagnosticsWindow->setBounds(result);
+	}
+	diagnosticsWindow->setVisible(true);
+	diagnosticsWindow->toFront(true);
 }
 
 std::shared_ptr<isobus::ControlFunction> ServerMainComponent::get_client_control_function_for_working_set(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet) const


### PR DESCRIPTION
## Summary

Add a separate, resizable Diagnostics window that displays active DM1 diagnostic trouble codes reported by other control functions on the bus. The window is opened explicitly from **Troubleshooting -> Diagnostics** and always starts closed.

## Approach

- subscribe to DM1 from any control function through the existing PGN callback API
- decode SPN, FMI, and occurrence count and replace each source's state on every full-state DM1 broadcast
- group active DTCs by source address and manufacturer from its address-claim NAME
- show textual, color-coded J1939 lamp indicators and an explicit `[LAMPS N/A]` state for ISO-mode messages
- clear a source immediately on an empty DM1 and age it out after seven seconds without another broadcast
- host the list in a resizable secondary window, wrapping lamp labels as its width changes
- unregister the raw CAN callback when the component is destroyed

## Validation

- verified single-frame and multi-packet DM1 decoding on `can0`
- ran `SeederExample` and `DiagnosticProtocolExample` together; the working set loaded while three active DTCs from the diagnostic source remained visible
- verified immediate clearing from an empty DM1 and aging after the source stopped broadcasting
- exercised individual and simultaneous MIL, STOP, WARN, and PROTECT lamp states with targeted J1939 DM1 frames
- verified two-axis window resizing with label wrapping and content shrinking without stale scrollbars

<img width="666" height="711" alt="Screenshot 2026-07-18 185039" src="https://github.com/user-attachments/assets/fb0e9e1d-dda6-4ed8-9324-81fce0b7f1ac" />
<img width="442" height="423" alt="Screenshot 2026-07-18 185140" src="https://github.com/user-attachments/assets/d9e3b008-2395-4a6c-b0cd-85da69381ee9" />
<img width="298" height="397" alt="Screenshot 2026-07-18 185632" src="https://github.com/user-attachments/assets/84603940-5313-4a4d-9ead-f68719b6cf38" />
<img width="451" height="225" alt="Screenshot 2026-07-18 185940" src="https://github.com/user-attachments/assets/62030869-a248-4902-9233-04e35344e58d" />

## Future scopes if needed

Other DTC message such as DM2, DM13 broadcast control, CSV export, human-readable SPN/FMI descriptions, etc.

Feel free to try this and let me know if there is any issues/bugs. Closes #186