### PR TITLE
Add a build for Ubuntu 26.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,3 +100,27 @@ jobs:
         with:
           name: 'Ubuntu 24.04 deb package'
           path: build/_CPack_Packages/Linux/DEB/*.deb
+  ubuntu_26_04_build:
+    name: Ubuntu 26.04 Build
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-tags: true
+          fetch-depth: 0
+      - name: Compile
+        run: |
+          mkdir build
+          sudo apt update
+          sudo apt install libasound2-dev libjack-jackd2-dev ladspa-sdk libcurl4-openssl-dev libfreetype-dev libfontconfig1-dev libx11-dev libxcomposite-dev libxcursor-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libglu1-mesa-dev mesa-common-dev git cmake
+          cmake -S . -B build -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -Wno-dev
+          cmake --build build --config Release
+          cd build
+          cpack -G DEB
+      - name: 'Upload Ubuntu 26.04 deb package'
+        uses: actions/upload-artifact@v7
+        with:
+          name: 'Ubuntu 26.04 deb package'
+          path: build/_CPack_Packages/Linux/DEB/*.deb


### PR DESCRIPTION
This adds an additional compile workflow for Ubuntu 26.04 to ensure we build on the most recent LTS release.