### PR TITLE
Small UI fixes

### DIFF
--- a/src/JuceManagedWorkingSetCache.cpp
+++ b/src/JuceManagedWorkingSetCache.cpp
@@ -212,7 +212,7 @@ std::shared_ptr<Component> JuceManagedWorkingSetCache::create_component(std::sha
 
 			case isobus::VirtualTerminalObjectType::WorkingSet:
 			{
-				retVal = std::make_shared<WorkingSetComponent>(workingSet, *std::static_pointer_cast<isobus::WorkingSet>(sourceObject), WorkingSetSelectorComponent::BUTTON_WIDTH, WorkingSetSelectorComponent::BUTTON_HEIGHT);
+				retVal = std::make_shared<WorkingSetComponent>(workingSet, *std::static_pointer_cast<isobus::WorkingSet>(sourceObject), WorkingSetSelectorComponent::BUTTON_HEIGHT, WorkingSetSelectorComponent::BUTTON_WIDTH);
 			}
 			break;
 

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -1411,7 +1411,7 @@ void ServerMainComponent::LanguageCommandConfigClosed::operator()(int result) co
 
 			mParent.softKeyMaskRenderer.setSize(mParent.softKeyMaskDimensions.total_width(), dataMaskSize.getIntValue());
 
-			mParent.vtNumber = mParent.popupMenu->getTextEditorContents("VT Number").getIntValue();
+			mParent.vtNumber = mParent.popupMenu->getTextEditorContents("VT number").getIntValue();
 			if (mParent.vtNumber > 32)
 			{
 				mParent.vtNumber = 32;

--- a/src/SoftKeyMaskComponent.cpp
+++ b/src/SoftKeyMaskComponent.cpp
@@ -41,7 +41,7 @@ void SoftKeyMaskComponent::on_content_changed(bool initial)
 			{
 				addAndMakeVisible(*childComponents.back());
 				childComponents.back()->setTopLeftPosition(x, y);
-				y += (dimensionInfo.PADDING + dimensionInfo.keyWidth);
+				y += (dimensionInfo.PADDING + dimensionInfo.keyHeight);
 
 				row++;
 				if (row >= dimensionInfo.rowCount)

--- a/src/WorkingSetSelectorComponent.cpp
+++ b/src/WorkingSetSelectorComponent.cpp
@@ -159,7 +159,7 @@ std::shared_ptr<Component> WorkingSetSelectorComponent::getWorkingSetChildCompon
 	}
 	else
 	{
-		workingSetComponent = std::make_shared<WorkingSetLoadingIndicatorComponent>(workingSet, BUTTON_WIDTH, BUTTON_HEIGHT);
+		workingSetComponent = std::make_shared<WorkingSetLoadingIndicatorComponent>(workingSet, BUTTON_HEIGHT, BUTTON_WIDTH);
 	}
 	workingSetComponent->setTopLeftPosition(button_padding(), button_padding() + workingSetIndex * (BUTTON_HEIGHT + button_padding()));
 	addAndMakeVisible(*workingSetComponent);


### PR DESCRIPTION
## Describe your changes

Three small fixes I found while looking into the soft key rendering for issue #188. This DOES NOT touch the data mask scaling problem explained in that issue.

- [ServerMainComponent.cpp](src/ServerMainComponent.cpp): While reading the VT number text editor, we tend to grab that object as `"VT Number"`, but it is registered as `"VT number"` on the `addTextEditor`. `getTextEditorContents()` is case-sensitive, so the lookup returned an empty string and `getIntValue()` give 0 every time.

- [SoftKeyMaskComponent.cpp](src/SoftKeyMaskComponent.cpp): I feel like this is a small unnoticed bug. `on_content_changed()` advanced the vertical position by `keyWidth` instead of `keyHeight`. The horizontal step on the next line already uses `keyWidth` and is correct so the vertical step should have been `keyHeight`. The default designators are 60x60, so the two are equal and nothing looks wrong until the configured height differs from the width. Please let me know if this is how it is designed.

- [JuceManagedWorkingSetCache.cpp](src/JuceManagedWorkingSetCache.cpp) and [WorkingSetSelectorComponent.cpp](src/WorkingSetSelectorComponent.cpp): Not really an issue right now as `BUTTON_WIDTH` and `BUTTON_HEIGHT` are the same value, but `WorkingSetComponent` and `WorkingSetLoadingIndicatorComponent` both take `keyHeight` as the argument before `keyWidth` in the constructor. So it might be confusing as to why `BUTTON_WIDTH` is sent on the argument for `keyHeight`.