### PR TITLE
Make CAN hardware config dialog modal to fix Z-order issue

### DIFF
--- a/src/ConfigureHardwareComponent.cpp
+++ b/src/ConfigureHardwareComponent.cpp
@@ -76,8 +76,6 @@ ConfigureHardwareComponent::ConfigureHardwareComponent(ConfigureHardwareWindow &
 	addAndMakeVisible(socketCANNameEditor);
 #endif
 	okButton.onClick = [this, &parent]() {
-		parent.setVisible(false);
-
 #ifdef JUCE_WINDOWS
 		if (3 == hardwareInterfaceSelector.getSelectedId()) // TouCAN
 		{
@@ -96,6 +94,8 @@ ConfigureHardwareComponent::ConfigureHardwareComponent(ConfigureHardwareWindow &
 		isobus::CANStackLogger::info("Updated socket CAN interface name to: " + socketCANNameEditor.getText().toStdString());
 #endif
 		parent.parentServer.save_settings();
+		parent.exitModalState(1);
+		parent.setVisible(false);
 	};
 }
 

--- a/src/ConfigureHardwareWindow.cpp
+++ b/src/ConfigureHardwareWindow.cpp
@@ -19,5 +19,6 @@ ConfigureHardwareWindow::ConfigureHardwareWindow(ServerMainComponent &parentComp
 
 void ConfigureHardwareWindow::closeButtonPressed()
 {
+	exitModalState(0);
 	setVisible(false);
 }

--- a/src/ServerMainComponent.cpp
+++ b/src/ServerMainComponent.cpp
@@ -1097,14 +1097,13 @@ bool ServerMainComponent::perform(const InvocationInfo &info)
 		case static_cast<int>(CommandIDs::ConfigureCANHardware):
 		{
 			configureHardwareWindow = std::make_unique<ConfigureHardwareWindow>(*this, parentCANDrivers);
-			configureHardwareWindow->addToDesktop();
 			Rectangle<int> area(0, 0, 400, 280);
 			RectanglePlacement placement(RectanglePlacement::centred |
 			                             RectanglePlacement::doNotResize);
 			auto result = placement.appliedTo(area, Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea.reduced(20));
 			configureHardwareWindow->setBounds(result);
 
-			configureHardwareWindow->setVisible(true);
+			configureHardwareWindow->enterModalState(true);
 			retVal = true;
 		}
 		break;


### PR DESCRIPTION
Fixes #173

`ConfigureHardwareWindow` was the only popup in `ServerMainComponent` not using a modal state. Switches it to `enterModalState()/exitModalState()`, same as the other dialogs so that it stay on top of main window.

Manually tested on simulation.