### PR TITLE
Scale object pools authored for a smaller data mask

### DIFF
--- a/include/DataMaskRenderAreaComponent.hpp
+++ b/include/DataMaskRenderAreaComponent.hpp
@@ -55,6 +55,11 @@ private:
 		std::uint32_t lastValue = 0;
 	};
 
+	/// @brief Takes a coordinate in this component's space back into the object pool's coordinates
+	/// @param[in] renderedCoordinate The coordinate as rendered, relative to this component
+	/// @returns The equivalent coordinate in the object pool's own coordinate space
+	int to_pool_coordinate(int renderedCoordinate) const;
+
 	std::shared_ptr<isobus::VTObject> getClickedChildRecursive(std::shared_ptr<isobus::VTObject> object, int x, int y);
 	static bool objectCanBeClicked(std::shared_ptr<isobus::VTObject> object);
 	static bool isClickWithinBounds(int clickXRelative, int clickYRelative, int objectX, int objectY, int objectWidth, int objectHeight);
@@ -69,6 +74,7 @@ private:
 	ServerMainComponent &ownerServer;
 	InputNumberListener inputNumberListener;
 	float renderScale = 1.0f;
+	int designedMaskSize = 0;
 	bool needToRepaintActiveArea = false;
 	bool hasStarted = false;
 

--- a/include/DataMaskRenderAreaComponent.hpp
+++ b/include/DataMaskRenderAreaComponent.hpp
@@ -68,6 +68,7 @@ private:
 	std::vector<std::shared_ptr<Component>> currentModalComponentCache;
 	ServerMainComponent &ownerServer;
 	InputNumberListener inputNumberListener;
+	float renderScale = 1.0f;
 	bool needToRepaintActiveArea = false;
 	bool hasStarted = false;
 

--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -20,8 +20,9 @@ constexpr int DESIGNED_MASK_SIZES[] = { 200, 240, 480 };
 /// park objects far outside the mask and wrap children in oversized containers, which makes the
 /// largest mask over-report the designed size by more than 4x.
 /// @param[in] workingSet The working set whose object pool should be measured
+/// @param[in] renderAreaSize The size in pixels of this VT's data mask render area
 /// @returns The estimated size in pixels of the data mask the pool was designed for
-static int detect_designed_mask_size(const std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> &workingSet)
+static int detect_designed_mask_size(const std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> &workingSet, int renderAreaSize)
 {
 	std::vector<int> maskExtents;
 
@@ -58,12 +59,18 @@ static int detect_designed_mask_size(const std::shared_ptr<isobus::VirtualTermin
 		}
 	}
 
-	auto retVal = DESIGNED_MASK_SIZES[std::size(DESIGNED_MASK_SIZES) - 1];
+	// With nothing measurable there is no evidence of a smaller design size, and reporting anything
+	// below the render area would scale the pool on a guess.
+	auto retVal = renderAreaSize;
 
 	if (!maskExtents.empty())
 	{
 		auto medianPosition = maskExtents.begin() + (maskExtents.size() / 2);
 		std::nth_element(maskExtents.begin(), medianPosition, maskExtents.end());
+
+		// A pool measuring past the end of the ladder is already full size. Reporting the last rung
+		// instead would scale it up on a VT whose render area is larger than that rung.
+		retVal = *medianPosition;
 
 		for (auto designedSize : DESIGNED_MASK_SIZES)
 		{
@@ -82,12 +89,27 @@ DataMaskRenderAreaComponent::DataMaskRenderAreaComponent(ServerMainComponent &pa
 {
 }
 
+int DataMaskRenderAreaComponent::to_pool_coordinate(int renderedCoordinate) const
+{
+	auto retVal = renderedCoordinate;
+
+	if (0 != designedMaskSize)
+	{
+		// The ratio is applied in integers rather than by dividing by renderScale, because a scale
+		// like 480/200 has no exact float representation and rounds an object's own boundary pixel
+		// into its neighbour.
+		retVal = (renderedCoordinate * designedMaskSize) / ownerServer.get_data_mask_area_size_x_pixels();
+	}
+	return retVal;
+}
+
 void DataMaskRenderAreaComponent::on_change_active_mask(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet)
 {
 	needToRepaintActiveArea = false;
 	childComponents.clear();
 	parentWorkingSet = workingSet;
 	renderScale = 1.0f;
+	designedMaskSize = 0;
 
 	if (parentWorkingSet)
 	{
@@ -95,12 +117,13 @@ void DataMaskRenderAreaComponent::on_change_active_mask(std::shared_ptr<isobus::
 
 		if ((nullptr != workingSetObject) && (isobus::NULL_OBJECT_ID != workingSetObject->get_active_mask()))
 		{
-			auto designedMaskSize = detect_designed_mask_size(parentWorkingSet);
+			auto detectedMaskSize = detect_designed_mask_size(parentWorkingSet, ownerServer.get_data_mask_area_size_x_pixels());
 
 			// Only ever scale up. Plenty of full size pools deliberately overhang the mask and rely on
 			// the VT clipping them, and shrinking those to fit would break pools that render fine today.
-			if (designedMaskSize < ownerServer.get_data_mask_area_size_x_pixels())
+			if (detectedMaskSize < ownerServer.get_data_mask_area_size_x_pixels())
 			{
+				designedMaskSize = detectedMaskSize;
 				renderScale = static_cast<float>(ownerServer.get_data_mask_area_size_x_pixels()) / designedMaskSize;
 			}
 
@@ -158,8 +181,8 @@ void DataMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 
 			auto relativeEvent = event.getEventRelativeTo(this);
 			auto clickedObject = getClickedChildRecursive(activeMask,
-			                                              static_cast<int>(relativeEvent.getMouseDownX() / renderScale),
-			                                              static_cast<int>(relativeEvent.getMouseDownY() / renderScale));
+			                                              to_pool_coordinate(relativeEvent.getMouseDownX()),
+			                                              to_pool_coordinate(relativeEvent.getMouseDownY()));
 
 			std::uint8_t keyCode = 1;
 
@@ -209,8 +232,8 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 
 			auto relativeEvent = event.getEventRelativeTo(this);
 			auto clickedObject = getClickedChildRecursive(activeMask,
-			                                              static_cast<int>(relativeEvent.getMouseDownX() / renderScale),
-			                                              static_cast<int>(relativeEvent.getMouseDownY() / renderScale));
+			                                              to_pool_coordinate(relativeEvent.getMouseDownX()),
+			                                              to_pool_coordinate(relativeEvent.getMouseDownY()));
 
 			std::uint8_t keyCode = 1;
 

--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -8,6 +8,75 @@
 #include "JuceManagedWorkingSetCache.hpp"
 #include "ServerMainComponent.hpp"
 
+#include <algorithm>
+
+/// The data mask sizes implements are actually authored against. 200 is the ISO 11783-6
+/// minimum; 240 is what the older Müller/Trimble terminals use.
+constexpr int DESIGNED_MASK_SIZES[] = { 200, 240, 480 };
+
+/// @brief Estimates the data mask size an object pool was drawn for
+/// @details Object pools do not declare this anywhere, and neither does ISO 11783-6, so it has
+/// to be measured. The median mask is used rather than the largest one because pools routinely
+/// park objects far outside the mask and wrap children in oversized containers, which makes the
+/// largest mask over-report the designed size by more than 4x.
+/// @param[in] workingSet The working set whose object pool should be measured
+/// @returns The estimated size in pixels of the data mask the pool was designed for
+static int detect_designed_mask_size(const std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> &workingSet)
+{
+	std::vector<int> maskExtents;
+
+	for (const auto &currentObject : workingSet->get_object_tree())
+	{
+		auto object = currentObject.second;
+
+		if ((nullptr == object) ||
+		    ((isobus::VirtualTerminalObjectType::DataMask != object->get_object_type()) &&
+		     (isobus::VirtualTerminalObjectType::AlarmMask != object->get_object_type())))
+		{
+			continue;
+		}
+
+		int extent = 0;
+
+		for (std::uint16_t i = 0; i < object->get_number_children(); i++)
+		{
+			auto child = object->get_object_by_id(object->get_child_id(i), workingSet->get_object_tree());
+
+			if ((nullptr == child) ||
+			    (isobus::VirtualTerminalObjectType::SoftKeyMask == child->get_object_type()))
+			{
+				continue;
+			}
+			extent = std::max(extent, object->get_child_x(i) + static_cast<int>(child->get_width()));
+			extent = std::max(extent, object->get_child_y(i) + static_cast<int>(child->get_height()));
+		}
+
+		// Masks with nothing sizable in them carry no signal, and partially cached pools have plenty.
+		if (0 != extent)
+		{
+			maskExtents.push_back(extent);
+		}
+	}
+
+	auto retVal = DESIGNED_MASK_SIZES[std::size(DESIGNED_MASK_SIZES) - 1];
+
+	if (!maskExtents.empty())
+	{
+		auto medianPosition = maskExtents.begin() + (maskExtents.size() / 2);
+		std::nth_element(maskExtents.begin(), medianPosition, maskExtents.end());
+
+		for (auto designedSize : DESIGNED_MASK_SIZES)
+		{
+			if (*medianPosition <= designedSize)
+			{
+				retVal = designedSize;
+				break;
+			}
+		}
+	}
+	return retVal;
+}
+
 DataMaskRenderAreaComponent::DataMaskRenderAreaComponent(ServerMainComponent &parentServer) :
   ownerServer(parentServer)
 {
@@ -18,6 +87,7 @@ void DataMaskRenderAreaComponent::on_change_active_mask(std::shared_ptr<isobus::
 	needToRepaintActiveArea = false;
 	childComponents.clear();
 	parentWorkingSet = workingSet;
+	renderScale = 1.0f;
 
 	if (parentWorkingSet)
 	{
@@ -25,9 +95,19 @@ void DataMaskRenderAreaComponent::on_change_active_mask(std::shared_ptr<isobus::
 
 		if ((nullptr != workingSetObject) && (isobus::NULL_OBJECT_ID != workingSetObject->get_active_mask()))
 		{
+			auto designedMaskSize = detect_designed_mask_size(parentWorkingSet);
+
+			// Only ever scale up. Plenty of full size pools deliberately overhang the mask and rely on
+			// the VT clipping them, and shrinking those to fit would break pools that render fine today.
+			if (designedMaskSize < ownerServer.get_data_mask_area_size_x_pixels())
+			{
+				renderScale = static_cast<float>(ownerServer.get_data_mask_area_size_x_pixels()) / designedMaskSize;
+			}
+
 			auto activeMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
 			childComponents.emplace_back(JuceManagedWorkingSetCache::create_component(parentWorkingSet, activeMask));
 			addAndMakeVisible(*childComponents.back());
+			childComponents.back()->setTransform(AffineTransform::scale(renderScale));
 		}
 	}
 	repaint();
@@ -77,7 +157,9 @@ void DataMaskRenderAreaComponent::mouseDown(const MouseEvent &event)
 			auto activeMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
 
 			auto relativeEvent = event.getEventRelativeTo(this);
-			auto clickedObject = getClickedChildRecursive(activeMask, relativeEvent.getMouseDownX(), relativeEvent.getMouseDownY());
+			auto clickedObject = getClickedChildRecursive(activeMask,
+			                                              static_cast<int>(relativeEvent.getMouseDownX() / renderScale),
+			                                              static_cast<int>(relativeEvent.getMouseDownY() / renderScale));
 
 			std::uint8_t keyCode = 1;
 
@@ -126,7 +208,9 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 			auto activeMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
 
 			auto relativeEvent = event.getEventRelativeTo(this);
-			auto clickedObject = getClickedChildRecursive(activeMask, relativeEvent.getMouseDownX(), relativeEvent.getMouseDownY());
+			auto clickedObject = getClickedChildRecursive(activeMask,
+			                                              static_cast<int>(relativeEvent.getMouseDownX() / renderScale),
+			                                              static_cast<int>(relativeEvent.getMouseDownY() / renderScale));
 
 			std::uint8_t keyCode = 1;
 

--- a/src/KeyComponent.cpp
+++ b/src/KeyComponent.cpp
@@ -7,12 +7,88 @@
 
 #include "JuceManagedWorkingSetCache.hpp"
 
+#include <algorithm>
+#include <vector>
+
+/// How far a designator's artwork may overhang the designator before it is scaled to fit. Pools
+/// authored against a slightly different designator size overhang by a few percent and are meant
+/// to be clipped, so only a gross overhang is treated as evidence of a different designator size.
+constexpr float MAXIMUM_UNSCALED_OVERHANG = 1.5f;
+
+/// @brief Estimates how much a pool's soft key designators need to be scaled to fit this VT's designators
+/// @details A Key has no size of its own in ISO 11783-6 - the VT supplies it - so a pool authored
+/// for larger designators just draws off the edge of ours and we clip it down to an unreadable
+/// fragment. The whole pool is measured rather than this one Key, and the median is taken rather
+/// than the largest, because individual designators legitimately park a shared background outside
+/// the designator and rely on the VT clipping it.
+/// @param[in] workingSet The working set whose object pool should be measured
+/// @param[in] keyWidth The width in pixels of a soft key designator on this VT
+/// @param[in] keyHeight The height in pixels of a soft key designator on this VT
+/// @returns The scale factor to render designator content at, or 1.0 to leave the pool alone
+static float detect_designator_content_scale(const std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> &workingSet, int keyWidth, int keyHeight)
+{
+	std::vector<int> extentsX, extentsY;
+
+	for (const auto &currentObject : workingSet->get_object_tree())
+	{
+		auto object = currentObject.second;
+
+		if ((nullptr == object) ||
+		    (isobus::VirtualTerminalObjectType::Key != object->get_object_type()))
+		{
+			continue;
+		}
+
+		int extentX = 0;
+		int extentY = 0;
+
+		for (std::uint16_t i = 0; i < object->get_number_children(); i++)
+		{
+			auto child = object->get_object_by_id(object->get_child_id(i), workingSet->get_object_tree());
+
+			if (nullptr == child)
+			{
+				continue;
+			}
+			extentX = std::max(extentX, object->get_child_x(i) + static_cast<int>(child->get_width()));
+			extentY = std::max(extentY, object->get_child_y(i) + static_cast<int>(child->get_height()));
+		}
+
+		// Designators with nothing sizable in them carry no signal, and pools have plenty of those.
+		if ((0 != extentX) && (0 != extentY))
+		{
+			extentsX.push_back(extentX);
+			extentsY.push_back(extentY);
+		}
+	}
+
+	auto retVal = 1.0f;
+
+	if (!extentsX.empty())
+	{
+		auto medianX = extentsX.begin() + (extentsX.size() / 2);
+		auto medianY = extentsY.begin() + (extentsY.size() / 2);
+
+		std::nth_element(extentsX.begin(), medianX, extentsX.end());
+		std::nth_element(extentsY.begin(), medianY, extentsY.end());
+
+		if ((*medianX > (keyWidth * MAXIMUM_UNSCALED_OVERHANG)) ||
+		    (*medianY > (keyHeight * MAXIMUM_UNSCALED_OVERHANG)))
+		{
+			retVal = std::min(keyWidth / static_cast<float>(*medianX), keyHeight / static_cast<float>(*medianY));
+		}
+	}
+	return retVal;
+}
+
 KeyComponent::KeyComponent(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> workingSet, isobus::Key sourceObject, int keyWidth, int keyHeight) :
   isobus::Key(sourceObject),
   parentWorkingSet(workingSet)
 {
 	setSize(keyWidth, keyHeight);
 	setOpaque(true);
+
+	auto contentScale = detect_designator_content_scale(parentWorkingSet, keyWidth, keyHeight);
 
 	for (std::uint16_t i = 0; i < this->get_number_children(); i++)
 	{
@@ -26,6 +102,7 @@ KeyComponent::KeyComponent(std::shared_ptr<isobus::VirtualTerminalServerManagedW
 			{
 				addAndMakeVisible(*childComponents.back());
 				childComponents.back()->setTopLeftPosition(get_child_x(i), get_child_y(i));
+				childComponents.back()->setTransform(AffineTransform::scale(contentScale));
 			}
 		}
 	}

--- a/src/KeyComponent.cpp
+++ b/src/KeyComponent.cpp
@@ -15,6 +15,28 @@
 /// to be clipped, so only a gross overhang is treated as evidence of a different designator size.
 constexpr float MAXIMUM_UNSCALED_OVERHANG = 1.5f;
 
+constexpr std::uint8_t MAXIMUM_POINTER_DEPTH = 4;
+
+/// @brief Resolves an object pointer to the object it ultimately points at
+/// @details A designator's artwork is usually reached through an object pointer, and a pointer
+/// carries no size of its own, so measuring the pointer reports the designator as empty.
+/// @param[in] workingSet The working set to resolve against
+/// @param[in] object The object to resolve
+/// @returns The pointed-at object, or the object itself if it is not a pointer
+static std::shared_ptr<isobus::VTObject> resolve_object_pointer(const std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> &workingSet, std::shared_ptr<isobus::VTObject> object)
+{
+	// Bounded rather than recursive, because a malformed pool can point a chain back at itself.
+	for (std::uint8_t depth = 0;
+	     (nullptr != object) &&
+	     (isobus::VirtualTerminalObjectType::ObjectPointer == object->get_object_type()) &&
+	     (depth < MAXIMUM_POINTER_DEPTH);
+	     depth++)
+	{
+		object = workingSet->get_object_by_id(std::static_pointer_cast<isobus::ObjectPointer>(object)->get_value());
+	}
+	return object;
+}
+
 /// @brief Estimates how much a pool's soft key designators need to be scaled to fit this VT's designators
 /// @details A Key has no size of its own in ISO 11783-6 - the VT supplies it - so a pool authored
 /// for larger designators just draws off the edge of ours and we clip it down to an unreadable
@@ -44,7 +66,7 @@ static float detect_designator_content_scale(const std::shared_ptr<isobus::Virtu
 
 		for (std::uint16_t i = 0; i < object->get_number_children(); i++)
 		{
-			auto child = object->get_object_by_id(object->get_child_id(i), workingSet->get_object_tree());
+			auto child = resolve_object_pointer(workingSet, object->get_object_by_id(object->get_child_id(i), workingSet->get_object_tree()));
 
 			if (nullptr == child)
 			{

--- a/src/KeyComponent.cpp
+++ b/src/KeyComponent.cpp
@@ -8,12 +8,18 @@
 #include "JuceManagedWorkingSetCache.hpp"
 
 #include <algorithm>
+#include <iterator>
 #include <vector>
 
 /// How far a designator's artwork may overhang the designator before it is scaled to fit. Pools
 /// authored against a slightly different designator size overhang by a few percent and are meant
-/// to be clipped, so only a gross overhang is treated as evidence of a different designator size.
-constexpr float MAXIMUM_UNSCALED_OVERHANG = 1.5f;
+/// to be clipped.
+constexpr float MAXIMUM_UNSCALED_OVERHANG = 1.1f;
+
+/// What share of a pool's designators must measure the same to read that measurement as the size
+/// the pool was authored for. A pool that merely overhangs scatters its measurements; a pool
+/// authored for a larger designator repeats the same one.
+constexpr float MINIMUM_DESIGNATOR_AGREEMENT = 0.5f;
 
 constexpr std::uint8_t MAXIMUM_POINTER_DEPTH = 4;
 
@@ -37,12 +43,43 @@ static std::shared_ptr<isobus::VTObject> resolve_object_pointer(const std::share
 	return object;
 }
 
+/// @brief Finds the value that most of a set of measurements agree on
+/// @param[in] values The measurements to look through
+/// @param[in] minimumAgreement The share of the measurements that must share a value
+/// @returns The agreed value, or 0 if too few of the measurements agree
+static int find_agreed_value(std::vector<int> values, float minimumAgreement)
+{
+	int retVal = 0;
+	std::size_t bestCount = 0;
+
+	std::sort(values.begin(), values.end());
+
+	for (auto runStart = values.begin(); runStart != values.end();)
+	{
+		auto runEnd = std::upper_bound(runStart, values.end(), *runStart);
+		auto count = static_cast<std::size_t>(std::distance(runStart, runEnd));
+
+		if (count > bestCount)
+		{
+			bestCount = count;
+			retVal = *runStart;
+		}
+		runStart = runEnd;
+	}
+
+	if (static_cast<float>(bestCount) < (static_cast<float>(values.size()) * minimumAgreement))
+	{
+		retVal = 0;
+	}
+	return retVal;
+}
+
 /// @brief Estimates how much a pool's soft key designators need to be scaled to fit this VT's designators
 /// @details A Key has no size of its own in ISO 11783-6 - the VT supplies it - so a pool authored
 /// for larger designators just draws off the edge of ours and we clip it down to an unreadable
-/// fragment. The whole pool is measured rather than this one Key, and the median is taken rather
-/// than the largest, because individual designators legitimately park a shared background outside
-/// the designator and rely on the VT clipping it.
+/// fragment. The whole pool is measured rather than this one Key, and the size the designators
+/// agree on is taken rather than the largest or the middle one, because individual designators
+/// legitimately park a shared background outside the designator and rely on the VT clipping it.
 /// @param[in] workingSet The working set whose object pool should be measured
 /// @param[in] keyWidth The width in pixels of a soft key designator on this VT
 /// @param[in] keyHeight The height in pixels of a soft key designator on this VT
@@ -85,20 +122,15 @@ static float detect_designator_content_scale(const std::shared_ptr<isobus::Virtu
 	}
 
 	auto retVal = 1.0f;
+	auto agreedX = find_agreed_value(extentsX, MINIMUM_DESIGNATOR_AGREEMENT);
+	auto agreedY = find_agreed_value(extentsY, MINIMUM_DESIGNATOR_AGREEMENT);
 
-	if (!extentsX.empty())
+	if ((0 != agreedX) &&
+	    (0 != agreedY) &&
+	    ((agreedX > (keyWidth * MAXIMUM_UNSCALED_OVERHANG)) ||
+	     (agreedY > (keyHeight * MAXIMUM_UNSCALED_OVERHANG))))
 	{
-		auto medianX = extentsX.begin() + (extentsX.size() / 2);
-		auto medianY = extentsY.begin() + (extentsY.size() / 2);
-
-		std::nth_element(extentsX.begin(), medianX, extentsX.end());
-		std::nth_element(extentsY.begin(), medianY, extentsY.end());
-
-		if ((*medianX > (keyWidth * MAXIMUM_UNSCALED_OVERHANG)) ||
-		    (*medianY > (keyHeight * MAXIMUM_UNSCALED_OVERHANG)))
-		{
-			retVal = std::min(keyWidth / static_cast<float>(*medianX), keyHeight / static_cast<float>(*medianY));
-		}
+		retVal = std::min(keyWidth / static_cast<float>(agreedX), keyHeight / static_cast<float>(agreedY));
 	}
 	return retVal;
 }


### PR DESCRIPTION
Looking to fix #188, and #172 which has the same root cause.

Those pools are authored against a 200 or 240 px data mask, so on our 480 px render area they draw at a fraction of the size up in the top-left corner. The VT now measures the pool's own geometry, snaps it to a designed mask size, and scales up to fill the render area. Clicks are mapped back through the same scale so presses still land on the right object.

Soft key designators get the same treatment separately so a pool authored for a larger designator just drew off the edge of ours and got clipped to an unreadable fragment.

Draft for now. Need to test this in multiple implements to make sure original data mask are not affected.