### PR TITLE
Guard against a null component when the active mask object cannot be rendered

### DIFF
--- a/src/DataMaskRenderAreaComponent.cpp
+++ b/src/DataMaskRenderAreaComponent.cpp
@@ -27,7 +27,11 @@ void DataMaskRenderAreaComponent::on_change_active_mask(std::shared_ptr<isobus::
 		{
 			auto activeMask = parentWorkingSet->get_object_by_id(workingSetObject->get_active_mask());
 			childComponents.emplace_back(JuceManagedWorkingSetCache::create_component(parentWorkingSet, activeMask));
-			addAndMakeVisible(*childComponents.back());
+
+			if (nullptr != childComponents.back())
+			{
+				addAndMakeVisible(*childComponents.back());
+			}
 		}
 	}
 	repaint();
@@ -215,13 +219,17 @@ void DataMaskRenderAreaComponent::mouseUp(const MouseEvent &event)
 								if (nullptr != child)
 								{
 									currentModalComponentCache.push_back(JuceManagedWorkingSetCache::create_component(parentWorkingSet, child));
-									auto text = "Object " + std::to_string(clickedList->get_child_id(static_cast<std::uint16_t>(i)));
-									if (child && child->get_object_type() == isobus::VirtualTerminalObjectType::OutputString)
-									{
-										text = std::static_pointer_cast<isobus::OutputString>(child)->displayed_value(parentWorkingSet->get_object_tree());
-									}
 
-									comboPopup->addCustomItem(i + 1, *currentModalComponentCache.back().get(), currentModalComponentCache.back()->getWidth(), currentModalComponentCache.back()->getHeight(), true, nullptr, text);
+									if (nullptr != currentModalComponentCache.back())
+									{
+										auto text = "Object " + std::to_string(clickedList->get_child_id(static_cast<std::uint16_t>(i)));
+										if (child->get_object_type() == isobus::VirtualTerminalObjectType::OutputString)
+										{
+											text = std::static_pointer_cast<isobus::OutputString>(child)->displayed_value(parentWorkingSet->get_object_tree());
+										}
+
+										comboPopup->addCustomItem(i + 1, *currentModalComponentCache.back().get(), currentModalComponentCache.back()->getWidth(), currentModalComponentCache.back()->getHeight(), true, nullptr, text);
+									}
 								}
 							}
 


### PR DESCRIPTION
## Describe your changes

The VT crashes if a client points Change Active Mask at an object which is not a mask. `on_change_active_mask()` calls `addAndMakeVisible()` on the result of `create_component()` without a null check, and `create_component()` returns `nullptr` for every non drawable type (NumberVariable, FontAttributes, Macro, WindowMask, KeyGroup and so on). The stack only checks
that the object ID exists, not that it is a DataMask or AlarmMask, so any ID from the client's own pool is accepted and we dereference null on the CAN update thread, which means a remote client can take the VT down. Fix: skip the child when the component is null, and the same check on the InputList popup path in `mouseUp()` which builds its components the same way. I think the stack should also reject a non mask object with `InvalidMaskObjectID`.